### PR TITLE
New templates

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -53,7 +53,8 @@ callosum_md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
 
 fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
                                 op.join(afq_home, 'callosum_templates'),
-                                baseurl, remote_fnames, callosum_fnames,
+                                baseurl, remote_callosum_fnames,
+                                callosum_fnames,
                                 md5_list=callosum_md5_hashes,
                                 doc="Download AFQ callosum templates")
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -9,57 +9,57 @@ afq_home = op.join(op.expanduser('~'), 'AFQ_data')
 
 baseurl = "https://ndownloader.figshare.com/files/"
 
-fnames = ["Callosum_midsag.nii.gz",
-          "L_AntFrontal.nii.gz",
-          "L_Motor.nii.gz",
-          "L_Occipital.nii.gz",
-          "L_Orbital.nii.gz",
-          "L_PostParietal.nii.gz",
-          "L_SupFrontal.nii.gz",
-          "L_SupParietal.nii.gz",
-          "L_Temporal.nii.gz",
-          "R_AntFrontal.nii.gz",
-          "R_Motor.nii.gz",
-          "R_Occipital.nii.gz",
-          "R_Orbital.nii.gz",
-          "R_PostParietal.nii.gz",
-          "R_SupFrontal.nii.gz",
-          "R_SupParietal.nii.gz",
-          "R_Temporal.nii.gz"]
+callosum_fnames = ["Callosum_midsag.nii.gz",
+                   "L_AntFrontal.nii.gz",
+                   "L_Motor.nii.gz",
+                   "L_Occipital.nii.gz",
+                   "L_Orbital.nii.gz",
+                   "L_PostParietal.nii.gz",
+                   "L_SupFrontal.nii.gz",
+                   "L_SupParietal.nii.gz",
+                   "L_Temporal.nii.gz",
+                   "R_AntFrontal.nii.gz",
+                   "R_Motor.nii.gz",
+                   "R_Occipital.nii.gz",
+                   "R_Orbital.nii.gz",
+                   "R_PostParietal.nii.gz",
+                   "R_SupFrontal.nii.gz",
+                   "R_SupParietal.nii.gz",
+                   "R_Temporal.nii.gz"]
 
-remote_fnames = ["5273794", "5273797", "5273800", "5273803", "5273806",
-                 "5273809", "5273812", "5273815", "5273821", "5273818",
-                 "5273824", "5273827", "5273830", "5273833", "5273836",
-                 "5273839", "5273842"]
+callosum_remote_fnames = ["5273794", "5273797", "5273800", "5273803",
+                          "5273806", "5273809", "5273812", "5273815",
+                          "5273821", "5273818", "5273824", "5273827",
+                          "5273830", "5273833", "5273836", "5273839",
+                          "5273842"]
 
-
-md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
-              "987c6169de807c4e93dc2cbd7a25d506",
-              "0da114123d0b0097b96fe450a459550b",
-              "6d845bd10504f67f1dc17f9000076d7e",
-              "e16c7873ef4b08d26b77ef746dab8237",
-              "47193fd4df1ea17367817466de798b90",
-              "7e78bf9671e6945f4b2f5e7c30595a3c",
-              "8adbb947377ff7b484c88d8c0ffc2125",
-              "0fd981a4d0847e0642ff96e84fe44e47",
-              "87c4855efa406d8fb004cffb8259180e",
-              "c7969bcf5f2343fd9ce9c49b336cf14c",
-              "bb4372b88991932150205ffb22aa6cb7",
-              "d198d4e7db18ddc7236cf143ecb8342e",
-              "d0f6edef64b0c710c92e634496085dda",
-              "85eaee44665f244db5adae2e259833f6",
-              "25f24eb22879a05d12bda007c81ea55a",
-              "2664e0b8c2d9c59f13649a89bfcce399"]
+callosum_md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
+                       "987c6169de807c4e93dc2cbd7a25d506",
+                       "0da114123d0b0097b96fe450a459550b",
+                       "6d845bd10504f67f1dc17f9000076d7e",
+                       "e16c7873ef4b08d26b77ef746dab8237",
+                       "47193fd4df1ea17367817466de798b90",
+                       "7e78bf9671e6945f4b2f5e7c30595a3c",
+                       "8adbb947377ff7b484c88d8c0ffc2125",
+                       "0fd981a4d0847e0642ff96e84fe44e47",
+                       "87c4855efa406d8fb004cffb8259180e",
+                       "c7969bcf5f2343fd9ce9c49b336cf14c",
+                       "bb4372b88991932150205ffb22aa6cb7",
+                       "d198d4e7db18ddc7236cf143ecb8342e",
+                       "d0f6edef64b0c710c92e634496085dda",
+                       "85eaee44665f244db5adae2e259833f6",
+                       "25f24eb22879a05d12bda007c81ea55a",
+                       "2664e0b8c2d9c59f13649a89bfcce399"]
 
 fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
                                 op.join(afq_home, 'callosum_templates'),
-                                baseurl, remote_fnames, fnames,
-                                md5_list=md5_hashes,
+                                baseurl, remote_fnames, callosum_fnames,
+                                md5_list=callosum_md5_hashes,
                                 doc="Download AFQ callosum templates")
 
 
 def read_callosum_templates():
-    """Load AFQ templates from file
+    """Load AFQ callosum templates from file
 
     Returns
     -------
@@ -71,6 +71,121 @@ def read_callosum_templates():
     for f in files:
         template_dict[f.split('.')[0]] = nib.load(op.join(folder, f))
     return template_dict
+
+
+template_fnames = ["ATR_roi1_L.nii.gz",
+                   "ATR_roi1_R.nii.gz",
+                   "ATR_roi2_L.nii.gz",
+                   "ATR_roi2_R.nii.gz",
+                   "CGC_roi1_L.nii.gz",
+                   "CGC_roi1_R.nii.gz",
+                   "CGC_roi2_L.nii.gz",
+                   "CGC_roi2_R.nii.gz",
+                   "CST_roi1_L.nii.gz",
+                   "CST_roi1_R.nii.gz",
+                   "CST_roi2_L.nii.gz",
+                   "CST_roi2_R.nii.gz",
+                   "FA_L.nii.gz",
+                   "FA_R.nii.gz",
+                   "FP_L.nii.gz",
+                   "FP_R.nii.gz",
+                   "HCC_roi1_L.nii.gz",
+                   "HCC_roi1_R.nii.gz",
+                   "HCC_roi2_L.nii.gz",
+                   "HCC_roi2_R.nii.gz",
+                   "IFO_roi1_L.nii.gz",
+                   "IFO_roi1_R.nii.gz",
+                   "IFO_roi2_L.nii.gz",
+                   "IFO_roi2_R.nii.gz",
+                   "ILF_roi1_L.nii.gz",
+                   "ILF_roi1_R.nii.gz",
+                   "ILF_roi2_L.nii.gz",
+                   "ILF_roi2_R.nii.gz",
+                   "SLF_roi1_L.nii.gz",
+                   "SLF_roi1_R.nii.gz",
+                   "SLF_roi2_L.nii.gz",
+                   "SLF_roi2_R.nii.gz",
+                   "SLFt_roi2_L.nii.gz",
+                   "SLFt_roi2_R.nii.gz",
+                   "UNC_roi1_L.nii.gz",
+                   "UNC_roi1_R.nii.gz",
+                   "UNC_roi2_L.nii.gz",
+                   "UNC_roi2_R.nii.gz"]
+
+template_remote_fnames = ["5273680", "5273683", "5273686", "5273689",
+                          "5273695", "5273692", "5273698", "5273701",
+                          "5273704", "5273707", "5273710", "5273713",
+                          "5273716", "5273719", "5273722", "5273725",
+                          "5273728", "5273731", "5273734", "5273746",
+                          "5273737", "5273740", "5273743", "5273749",
+                          "5273752", "5273755", "5273758", "5273761",
+                          "5273764", "5273767", "5273770", "5273773",
+                          "5273776", "5273791", "5273779", "5273782",
+                          "5273785", "5273788"]
+
+
+template_md5_hashes = ["6b7aaed1a2982fd0ea436a223133908b",
+                       "fd60d46d4e3cbd906c86e4c9e4fd6e2a",
+                       "3aba60b169a35c38640de4ec29d362c8",
+                       "12716a5688a1809fbaed1d58d2e68b59",
+                       "8e8973bc7838c8744914d402f52d91ca",
+                       "c5fa4e6e685e695c006823b6784d2407",
+                       "e1fab77f21d5303ed52285f015e24f0b",
+                       "5f89defec3753fd75cd688c7bfb20a36",
+                       "f9db3154955a20b67c2dda758800d14c",
+                       "73941510c798c1ed1b03e2bd481cd5c7",
+                       "660cdc031ee0716d60159c7d933119ea",
+                       "660cdc031ee0716d60159c7d933119ea",
+                       "9040a7953dcbbf131d135c866182d8ef",
+                       "a72e17194824fcd838a594a2eb50c72e",
+                       "55adbe9b8279185eedbe342149e1ff90",
+                       "5a7412a3cf0fb185eec53d1989df2f7c",
+                       "ba453196ff179b0e31172806e313b52c",
+                       "d85c6574526b296935f34bf4f65cd493",
+                       "9b81646317f59c7db087f27e2f85679e",
+                       "9806e82c250e4604534b96917f87b7e8",
+                       "0e68a9feaaddcc9b4d667c2f15903368",
+                       "d45020a87ee4bb496edd350631d91f6a",
+                       "75c2c911826ec4b23159f9bd80e3c039",
+                       "55d616ea9e0c646adc1aafa0f5fbe625",
+                       "045b7d5c6341997f3f0120c3a4212ad8",
+                       "d174b1359ba982b03840436c93b7bbb4",
+                       "fff9753f394fc4c73fb2ae40b3b4dde0",
+                       "cd278b4dd6ff77481ea9ac16485a5ae2",
+                       "af2bcedf47e193686af329b9a8e259da",
+                       "9a1122943579d11ba169d3ad87a75625",
+                       "627903f7a06627bfd4153dc9245fa390",
+                       "1714cd7f989c3435bdd5a2076e6272a0",
+                       "1fa2114049707a4e05b53f9d95730375",
+                       "b6663067d5ea53c70cb8803948f8adf7",
+                       "fa141bb2d951bec486916acda3652d95",
+                       "d391d073e86e28588be9a6d01b2e7a82",
+                       "a3e085562e6b8111c7ebc358f9450c8b",
+                       "d65c67910807504735e034f7ea92d590"]
+
+fetch_templates = _make_fetcher("fetch_templates",
+                                op.join(afq_home, 'templates'),
+                                baseurl, template_remote_fnames,
+                                template_fnames, md5_list=template_md5_hashes,
+                                doc="Download AFQ callosum templates")
+
+
+def read_templates():
+    """Load AFQ templates from file
+
+    Returns
+    -------
+    dict with: keys: names of template ROIs and values: nibabel Nifti1Image
+    objects from each of the ROI nifti files.
+    """
+    files, folder = fetch_templates()
+    template_dict = {}
+    for f in files:
+        template_dict[f.split('.')[0]] = nib.load(op.join(folder, f))
+    return template_dict
+
+
+
 
 
 def fetch_hcp(subjects):

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -6,8 +6,8 @@ import nibabel as nib
 from dipy.data.fetcher import _make_fetcher
 
 afq_home = op.join(op.expanduser('~'), 'AFQ_data')
-baseurl = ("https://digital.lib.washington.edu/researchworks" +
-           "/bitstream/handle/1773/34926/")
+
+baseurl = "https://ndownloader.figshare.com/files/"
 
 fnames = ["Callosum_midsag.nii.gz",
           "L_AntFrontal.nii.gz",
@@ -27,6 +27,12 @@ fnames = ["Callosum_midsag.nii.gz",
           "R_SupParietal.nii.gz",
           "R_Temporal.nii.gz"]
 
+remote_fnames = ["5273794", "5273797", "5273800", "5273803", "5273806",
+                 "5273809", "5273812", "5273815", "5273821", "5273818",
+                 "5273824", "5273827", "5273830", "5273833", "5273836",
+                 "5273839", "5273842"]
+
+
 md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
               "987c6169de807c4e93dc2cbd7a25d506",
               "0da114123d0b0097b96fe450a459550b",
@@ -45,14 +51,14 @@ md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
               "25f24eb22879a05d12bda007c81ea55a",
               "2664e0b8c2d9c59f13649a89bfcce399"]
 
-fetch_templates = _make_fetcher("fetch_templates",
-                                op.join(afq_home, 'templates'),
-                                baseurl, fnames, fnames,
+fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
+                                op.join(afq_home, 'callosum_templates'),
+                                baseurl, remote_fnames, fnames,
                                 md5_list=md5_hashes,
-                                doc="Download AFQ templates")
+                                doc="Download AFQ callosum templates")
 
 
-def read_templates():
+def read_callosum_templates():
     """Load AFQ templates from file
 
     Returns
@@ -60,7 +66,7 @@ def read_templates():
     dict with: keys: names of template ROIs and values: nibabel Nifti1Image
     objects from each of the ROI nifti files.
     """
-    files, folder = fetch_templates()
+    files, folder = fetch_callosum_templates()
     template_dict = {}
     for f in files:
         template_dict[f.split('.')[0]] = nib.load(op.join(folder, f))

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -51,13 +51,13 @@ callosum_md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
                        "25f24eb22879a05d12bda007c81ea55a",
                        "2664e0b8c2d9c59f13649a89bfcce399"]
 
-fetch_callosum_templates = _make_fetcher(
-                                "fetch_callosum_templates",
-                                op.join(afq_home, 'callosum_templates'),
-                                baseurl, callosum_remote_fnames,
-                                callosum_fnames,
-                                md5_list=callosum_md5_hashes,
-                                doc="Download AFQ callosum templates")
+fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
+                                         op.join(afq_home,
+                                                 'callosum_templates'),
+                                         baseurl, callosum_remote_fnames,
+                                         callosum_fnames,
+                                         md5_list=callosum_md5_hashes,
+                                         doc="Download AFQ callosum templates")
 
 
 def read_callosum_templates():
@@ -185,7 +185,7 @@ def read_templates():
     for f in files:
         template_dict[f.split('.')[0]] = nib.load(op.join(folder, f))
     return template_dict
-    
+
 
 def fetch_hcp(subjects):
     """

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -53,7 +53,7 @@ callosum_md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
 
 fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
                                 op.join(afq_home, 'callosum_templates'),
-                                baseurl, remote_callosum_fnames,
+                                baseurl, callosum_remote_fnames,
                                 callosum_fnames,
                                 md5_list=callosum_md5_hashes,
                                 doc="Download AFQ callosum templates")

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -51,7 +51,8 @@ callosum_md5_hashes = ["709fa90baadeacd64f1d62b5049a4125",
                        "25f24eb22879a05d12bda007c81ea55a",
                        "2664e0b8c2d9c59f13649a89bfcce399"]
 
-fetch_callosum_templates = _make_fetcher("fetch_callosum_templates",
+fetch_callosum_templates = _make_fetcher(
+                                "fetch_callosum_templates",
                                 op.join(afq_home, 'callosum_templates'),
                                 baseurl, callosum_remote_fnames,
                                 callosum_fnames,
@@ -184,10 +185,7 @@ def read_templates():
     for f in files:
         template_dict[f.split('.')[0]] = nib.load(op.join(folder, f))
     return template_dict
-
-
-
-
+    
 
 def fetch_hcp(subjects):
     """


### PR DESCRIPTION
This PR adds the JHU ROI templates, and clarifies the difference with the callosal templates. I have also switched to using figshare, instead of Researchworks, because it's easier to deal with.