### PR TITLE
Early track checks

### DIFF
--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -29,8 +29,8 @@ TissueTypes = Bunch(OUTSIDEIMAGE=-1, INVALIDPOINT=0, TRACKPOINT=1, ENDPOINT=2)
 class VerboseLocalTracking(LocalTracking):
     def __init__(self, *args, min_length=10, max_length=250, **kwargs):
         super().__init__(*args, **kwargs)
-        self.min_length=min_length
-        self.max_length=max_length
+        self.min_length = min_length
+        self.max_length = max_length
 
     def _generate_streamlines(self):
         """A streamline generator"""

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -67,7 +67,12 @@ class VerboseLocalTracking(LocalTracking):
                 else:
                     parts = (B[stepsB - 1:0:-1], F[:stepsF])
                     streamline = np.concatenate(parts, axis=0)
-                yield streamline
+
+                len_sl = len(streamline)
+                if len_sl < 10 or len_sl > 250:
+                    continue
+                else:
+                    yield streamline
 
 
 def in_place_norm(vec, axis=-1, keepdims=False, delvec=True):

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -27,10 +27,12 @@ TissueTypes = Bunch(OUTSIDEIMAGE=-1, INVALIDPOINT=0, TRACKPOINT=1, ENDPOINT=2)
 
 
 class VerboseLocalTracking(LocalTracking):
-    def __init__(self, *args, min_length=10, max_length=250, **kwargs):
+    def __init__(self, *args, min_length=10, max_length=250, step_size=0.5,
+                 **kwargs):
         super().__init__(*args, **kwargs)
         self.min_length = min_length
         self.max_length = max_length
+        self.step_size = self.step_size
 
     def _generate_streamlines(self):
         """A streamline generator"""
@@ -74,7 +76,8 @@ class VerboseLocalTracking(LocalTracking):
                     streamline = np.concatenate(parts, axis=0)
 
                 len_sl = len(streamline)
-                if len_sl < self.min_length or len_sl > self.max_length:
+                if len_sl < self.min_length * self.step_size \
+                    or len_sl > self.max_length * self.step_size:
                     continue
                 else:
                     yield streamline

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -27,6 +27,11 @@ TissueTypes = Bunch(OUTSIDEIMAGE=-1, INVALIDPOINT=0, TRACKPOINT=1, ENDPOINT=2)
 
 
 class VerboseLocalTracking(LocalTracking):
+    def __init__(self, *args, min_length=10, max_length=250, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.min_length=min_length
+        self.max_length=max_length
+
     def _generate_streamlines(self):
         """A streamline generator"""
 
@@ -69,7 +74,7 @@ class VerboseLocalTracking(LocalTracking):
                     streamline = np.concatenate(parts, axis=0)
 
                 len_sl = len(streamline)
-                if len_sl < 10 or len_sl > 250:
+                if len_sl < self.min_length or len_sl > self.max_length:
                     continue
                 else:
                     yield streamline

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -10,6 +10,7 @@ import random
 import sys
 import math
 
+
 def spherical_harmonics(m, n, theta, phi):
     """
     An implementation of spherical harmonics that overcomes conda compilation
@@ -77,7 +78,7 @@ class VerboseLocalTracking(LocalTracking):
 
                 len_sl = len(streamline)
                 if len_sl < self.min_length * self.step_size \
-                    or len_sl > self.max_length * self.step_size:
+                        or len_sl > self.max_length * self.step_size:
                     continue
                 else:
                     yield streamline

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -28,12 +28,10 @@ TissueTypes = Bunch(OUTSIDEIMAGE=-1, INVALIDPOINT=0, TRACKPOINT=1, ENDPOINT=2)
 
 
 class VerboseLocalTracking(LocalTracking):
-    def __init__(self, *args, min_length=10, max_length=250, step_size=0.5,
-                 **kwargs):
+    def __init__(self, *args, min_length=10, max_length=250, **kwargs):
         super().__init__(*args, **kwargs)
         self.min_length = min_length
         self.max_length = max_length
-        self.step_size = self.step_size
 
     def _generate_streamlines(self):
         """A streamline generator"""

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -142,7 +142,4 @@ def _local_tracking(seeds, dg, threshold_classifier, affine,
                         affine,
                         step_size=step_size)
 
-    streamlines = dts.Streamlines(tracker)
-    streamlines = streamlines[streamlines._lengths * step_size > min_length]
-    streamlines = streamlines[streamlines._lengths * step_size < max_length]
-    return streamlines
+    return dts.Streamlines(tracker)

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -140,6 +140,8 @@ def _local_tracking(seeds, dg, threshold_classifier, affine,
                         threshold_classifier,
                         seeds,
                         affine,
-                        step_size=step_size)
+                        step_size=step_size,
+                        min_length=min_length,
+                        max_length=max_length)
 
     return dts.Streamlines(tracker)


### PR DESCRIPTION
Move check for streamline length into tracker, so too small or too large streamlines can be thrown out without having to be saved. 