### PR TITLE
Transform streamlines using SFT methods.

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -445,8 +445,8 @@ def _clean_bundles(row, wm_labels, bundle_dict, reg_template, odf_model="DTI",
                                 force_recompute=force_recompute)
 
         sft = load_tractogram(bundles_file,
-                             row['dwi_img'],
-                             Space.VOX)
+                              row['dwi_img'],
+                              Space.VOX)
 
         tgram = nib.streamlines.Tractogram([], {'bundle': []})
 
@@ -478,7 +478,7 @@ def _clean_bundles(row, wm_labels, bundle_dict, reg_template, odf_model="DTI",
 def _tract_profiles(row, wm_labels, bundle_dict, reg_template,
                     odf_model="DTI", directions="det",
                     n_seeds=2, random_seeds=False,
-                    scalars=["dti_fa", "dti_md"], weighting=None,
+                    scalars=_scalar_dict.keys(), weighting=None,
                     force_recompute=False):
     profiles_file = _get_fname(row, '_profiles.csv')
     if not op.exists(profiles_file) or force_recompute:

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -405,9 +405,8 @@ def _segment(row, wm_labels, bundle_dict, reg_template, method="AFQ",
             n_seeds=n_seeds,
             random_seeds=random_seeds,
             force_recompute=force_recompute)
-
-        tg = load_tractogram(streamlines_file, nib.load(row['dwi_file']))
-        tg.to_vox()
+        img = nib.load(row['dwi_file'])
+        tg = load_tractogram(streamlines_file, img, Space.VOX)
 
         reg_prealign = np.load(
             _reg_prealign(row, force_recompute=force_recompute))
@@ -424,8 +423,8 @@ def _segment(row, wm_labels, bundle_dict, reg_template, method="AFQ",
                                        mapping=_mapping(row, reg_template),
                                        reg_prealign=reg_prealign)
 
-        tgram = aus.bundles_to_tgram(bundles, bundle_dict, row['dwi_affine'])
-        nib.streamlines.save(tgram, bundles_file)
+        tgram = aus.bundles_to_tgram(bundles, bundle_dict, img)
+        save_tractogram(tgram, bundles_file)
     return bundles_file
 
 

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -392,7 +392,7 @@ def _streamlines(row, wm_labels, odf_model="DTI", directions="det",
 def _segment(row, wm_labels, bundle_dict, reg_template, method="AFQ",
              odf_model="DTI", directions="det", n_seeds=2,
              random_seeds=False, force_recompute=False,
-             filter_by_endpoints=False):
+             **segmentation_params):
     bundles_file = _get_fname(row,
                               '%s_%s_bundles.trk' % (odf_model,
                                                      directions))
@@ -412,7 +412,7 @@ def _segment(row, wm_labels, bundle_dict, reg_template, method="AFQ",
 
         segmentation = seg.Segmentation(
             algo=method,
-            filter_by_endpoints=filter_by_endpoints)
+            **segmentation_params)
         bundles = segmentation.segment(bundle_dict,
                                        tg,
                                        row['dwi_file'],
@@ -705,7 +705,7 @@ class AFQ(object):
                  force_recompute=False,
                  reg_template=None,
                  wm_labels=[250, 251, 252, 253, 254, 255, 41, 2, 16, 77],
-                 filter_by_endpoints=False):
+                 **segmentation_params):
         """
 
         dmriprep_path: str
@@ -747,7 +747,7 @@ class AFQ(object):
         self.wm_labels = wm_labels
         self.n_seeds = n_seeds
         self.random_seeds = random_seeds
-        self.filter_by_endpoints = filter_by_endpoints
+        self.segmentation_params = segmentation_params
         if reg_template is None:
             self.reg_template = dpd.read_mni_template()
         else:
@@ -1015,7 +1015,7 @@ class AFQ(object):
                     n_seeds=self.n_seeds,
                     random_seeds=self.random_seeds,
                     force_recompute=self.force_recompute,
-                    filter_by_endpoints=self.filter_by_endpoints)
+                    **self.segmentation_params)
 
     def get_bundles(self):
         self.set_bundles()

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -695,7 +695,7 @@ def bundles_to_aal(bundles, atlas=None):
         "ILF_L": [['leftoccipital'], ['leftilftemp']],
         "ILF_R": [['rightoccipital'], ['rightilftemp']],
         "SLF_L": [['leftinfparietal'], ['leftslffrontal']],
-        "SLF_R": [['rightinfparietal'],['rightslffrontal']],
+        "SLF_R": [['rightinfparietal'], ['rightslffrontal']],
         "UNC_L": [['leftanttemporal'], ['leftuncinatefront']],
         "UNC_R": [['rightanttemporal'], ['rightuncinatefront']],
         "ARC_L": [['leftfrontal'], ['leftarctemp']],

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -32,7 +32,7 @@ def _resample_tg(tg, n_points):
     else:
         streamlines = tg.streamlines
 
-    return np.array(dps.set_number_of_points(streamlines, n_points))
+    return dps.set_number_of_points(streamlines, n_points)
 
 
 class Segmentation:
@@ -407,7 +407,7 @@ class Segmentation:
             self.tg = tg
 
         # For expedience, we approximate each streamline as a 100 point curve:
-        fgarray = _resample_tg(tg, 100)
+        fgarray = np.array(_resample_tg(tg, 100))
 
         n_streamlines = fgarray.shape[0]
 

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -512,7 +512,8 @@ class Segmentation:
                 # There's nothing here, move to the next bundle:
                 continue
 
-            # Use a list here, Streamlines don't support item assignment:
+            # Use a list here, because ArraySequence doesn't support item
+            # assignment:
             select_sl = list(tg.streamlines[select_idx])
             # Sub-sample min_dist_coords:
             min_dist_coords_bundle = min_dist_coords[select_idx]
@@ -521,6 +522,9 @@ class Segmentation:
                 min1 = min_dist_coords_bundle[idx, bundle_idx, 1]
                 if min0 > min1:
                     select_sl[idx] = select_sl[idx][::-1]
+
+            # Set this to StatefulTractogram object for filtering/output:
+            select_sl = StatefulTractogram(select_sl, self.img, Space.VOX)
 
             if self.filter_by_endpoints:
                 self.logger.info("Filtering by endpoints")
@@ -540,16 +544,18 @@ class Segmentation:
 
                 self.logger.info("Before filtering "
                                  f"{len(select_sl)} streamlines")
+
                 select_sl = clean_by_endpoints(select_sl.streamlines,
                                                aal_idx[0],
                                                aal_idx[1],
                                                tol=dist_to_aal)
+                # Generate immediately:
+                select_sl = StatefulTractogram(select_sl,
+                                               self.img,
+                                               Space.RASMM)
 
                 self.logger.info("After filtering "
                                  f"{len(select_sl)} streamlines")
-
-            # Set this to StatefulTractogram object for output:
-            select_sl = StatefulTractogram(select_sl, self.img, Space.VOX)
 
             if self.return_idx:
                 self.fiber_groups[bundle] = {}

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -713,8 +713,9 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=5,
         # Repeat:
         w = gaussian_weights(fgarray, return_mahalnobis=True)
         rounds_elapsed += 1
+
     # Select based on the variable that was keeping track of things for us:
-    out = streamlines[idx]
+    out = StatefulTractogram(tg.streamlines[idx], tg, Space.VOX)
     if return_idx:
         return out, idx
     else:

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -499,22 +499,21 @@ class Segmentation:
             self.logger.info(f"Processing {bundle}")
 
             select_idx = np.where(bundle_choice == bundle_idx)
-            # Use a list here, Streamlines don't support item assignment:
-            select_sl = StatefulTractogram(tg.streamlines[select_idx],
-                                           self.img,
-                                           Space.VOX)
-            if len(select_sl.streamlines) == 0:
+
+            if len(select_idx[0]) == 0:
                 if self.return_idx:
                     self.fiber_groups[bundle] = {}
                     self.fiber_groups[bundle]['sl'] = StatefulTractogram(
-                        [], self.img, space.VOX)
+                        [], self.img, Space.VOX)
                     self.fiber_groups[bundle]['idx'] = np.array([])
                 else:
                     self.fiber_groups[bundle] = StatefulTractogram(
-                        [], self.img, space.VOX)
+                        [], self.img, Space.VOX)
                 # There's nothing here, move to the next bundle:
                 continue
 
+            # Use a list here, Streamlines don't support item assignment:
+            select_sl = list(tg.streamlines[select_idx])
             # Sub-sample min_dist_coords:
             min_dist_coords_bundle = min_dist_coords[select_idx]
             for idx in range(len(select_sl)):
@@ -522,13 +521,6 @@ class Segmentation:
                 min1 = min_dist_coords_bundle[idx, bundle_idx, 1]
                 if min0 > min1:
                     select_sl[idx] = select_sl[idx][::-1]
-
-            select_sl = StatefulTractogram(select_sl.streamlines,
-                                           self.img,
-                                           Space.VOX)
-
-            # Set this to StatefulTractogram object for output:
-            # select_sl = StatefulTractogram(select_sl, self.img, Space.VOX)
 
             if self.filter_by_endpoints:
                 self.logger.info("Filtering by endpoints")
@@ -552,12 +544,12 @@ class Segmentation:
                                                aal_idx[0],
                                                aal_idx[1],
                                                tol=dist_to_aal)
-                select_sl = StatefulTractogram(select_sl,
-                                               self.img,
-                                               Space.VOX)
 
                 self.logger.info("After filtering "
                                  f"{len(select_sl)} streamlines")
+
+            # Set this to StatefulTractogram object for output:
+            select_sl = StatefulTractogram(select_sl, self.img, Space.VOX)
 
             if self.return_idx:
                 self.fiber_groups[bundle] = {}

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -407,10 +407,8 @@ class Segmentation:
             roi = self.bundle_dict[bundle]['ROIs'][rule_idx]
             if not isinstance(roi, np.ndarray):
                 roi = roi.get_fdata()
-            warped_roi = auv.patch_up_roi(
-                (self.mapping.transform_inverse(
-                    roi.astype(np.float32),
-                    interpolation='linear')) > 0)
+            warped_roi = auv.patch_up_roi(self.mapping.transform_inverse(
+                roi.astype(np.float32), interpolation='linear'))
 
             if rule:
                 # include ROI:

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -104,7 +104,8 @@ def test_AFQ_data_waypoint():
                     sub_prefix='sub',
                     seg_algo=seg_algo,
                     bundle_names=bundle_names,
-                    odf_model="DTI")
+                    odf_model="DTI",
+                    filter_by_endpoints=False)
 
     # Replace the mapping and streamlines with precomputed:
     file_dict = afd.read_stanford_hardi_tractography()

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -16,7 +16,7 @@ import dipy.tracking.utils as dtu
 import dipy.tracking.streamline as dts
 import dipy.data as dpd
 from dipy.data import fetcher
-from dipy.io.streamline import save_tractogram
+from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 
 from AFQ import api
@@ -128,7 +128,8 @@ def test_AFQ_data_waypoint():
                                 'sub-01_sess-01_dwi_reg_prealign.npy')
     np.save(reg_prealign_file, np.eye(4))
 
-    tgram = nib.streamlines.load(myafq.bundles[0]).tractogram
+    tgram = load_tractogram(myafq.bundles[0], myafq.dwi_img[0])
+
     bundles = aus.tgram_to_bundles(tgram, myafq.bundle_dict)
     npt.assert_(len(bundles['CST_L']) > 0)
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -130,7 +130,7 @@ def test_AFQ_data_waypoint():
 
     tgram = load_tractogram(myafq.bundles[0], myafq.dwi_img[0])
 
-    bundles = aus.tgram_to_bundles(tgram, myafq.bundle_dict)
+    bundles = aus.tgram_to_bundles(tgram, myafq.bundle_dict, myafq.dwi_img[0])
     npt.assert_(len(bundles['CST_L']) > 0)
 
     # Test ROI exporting:

--- a/AFQ/utils/streamlines.py
+++ b/AFQ/utils/streamlines.py
@@ -1,5 +1,6 @@
 import numpy as np
 import nibabel as nib
+from dipy.io.stateful_tractogram import StatefulTractogram, Space
 
 
 def add_bundles(t1, t2):
@@ -19,7 +20,7 @@ def add_bundles(t1, t2):
         affine_to_rasmm=t2.affine_to_rasmm)
 
 
-def bundles_to_tgram(bundles, bundle_dict, affine):
+def bundles_to_tgram(bundles, bundle_dict, reference):
     """
     Create a nibabel trk Tractogram object from bundles and their
     specification.
@@ -31,20 +32,20 @@ def bundles_to_tgram(bundles, bundle_dict, affine):
     bundle_dict: dict
         A bundle specification dictionary. Each item includes in particular a
         `uid` key that is a unique integer for that bundle.
-    affine : array
+    reference : Nifti
         The affine_to_rasmm input to `nib.streamlines.Tractogram`
     """
     tgram = nib.streamlines.Tractogram([], {'bundle': []})
     for b in bundles:
-        this_sl = bundles[b]
+        this_sl = bundles[b].streamlines
         this_tgram = nib.streamlines.Tractogram(
             this_sl,
             data_per_streamline={
                 'bundle': (len(this_sl)
                            * [bundle_dict[b]['uid']])},
-                affine_to_rasmm=affine)
+                affine_to_rasmm=reference.affine)
         tgram = add_bundles(tgram, this_tgram)
-    return tgram
+    return StatefulTractogram(tgram.streamlines, reference, Space.VOX)
 
 
 def tgram_to_bundles(tgram, bundle_dict):

--- a/AFQ/utils/streamlines.py
+++ b/AFQ/utils/streamlines.py
@@ -22,7 +22,7 @@ def add_bundles(t1, t2):
 
 def bundles_to_tgram(bundles, bundle_dict, reference):
     """
-    Create a nibabel trk Tractogram object from bundles and their
+    Create a StatefulTractogram object from bundles and their
     specification.
 
     Parameters
@@ -45,18 +45,18 @@ def bundles_to_tgram(bundles, bundle_dict, reference):
                            * [bundle_dict[b]['uid']])},
                 affine_to_rasmm=reference.affine)
         tgram = add_bundles(tgram, this_tgram)
-    return StatefulTractogram(tgram.streamlines, reference, Space.VOX)
+    return StatefulTractogram(tgram.streamlines, reference, Space.VOX,
+                              data_per_streamline=tgram.data_per_streamline)
 
 
-def tgram_to_bundles(tgram, bundle_dict):
+def tgram_to_bundles(tgram, bundle_dict, reference):
     """
-    Convert a nib.streamlines.Tractogram object to a dict with items
-    holding the streamlines in each bundle.
+    Convert a StatefulTractogram object to a dict with StatefulTractogram
+    objects for each bundle.
 
     Parameters
     ----------
-    tgram : nib.streamlines.Tractogram class instance.
-
+    tgram : StatefulTractogram class instance.
         Requires a data_per_streamline['bundle'][bundle_name]['uid'] attribute.
 
     bundle_dict: dict
@@ -68,7 +68,8 @@ def tgram_to_bundles(tgram, bundle_dict):
         if not bb == 'whole_brain':
             uid = bundle_dict[bb]['uid']
             idx = np.where(tgram.data_per_streamline['bundle'] == uid)[0]
-            bundles[bb] = tgram[idx].streamlines.copy()
+            bundles[bb] = StatefulTractogram(
+                tgram.streamlines[idx].copy(), reference, Space.VOX)
     return bundles
 
 

--- a/AFQ/utils/volume.py
+++ b/AFQ/utils/volume.py
@@ -3,7 +3,7 @@ from skimage.filters import gaussian
 from skimage.morphology import convex_hull_image
 
 
-def patch_up_roi(roi, sigma=0.5, truncate=2):
+def patch_up_roi(roi):
     """
     After being non-linearly transformed, ROIs tend to have holes in them.
     We perform a couple of computational geometry operations on the ROI to
@@ -25,5 +25,4 @@ def patch_up_roi(roi, sigma=0.5, truncate=2):
     ROI after dilation and hole-filling
     """
 
-    return convex_hull_image(gaussian(ndim.binary_fill_holes(roi),
-                                      sigma=sigma, truncate=truncate) > 0)
+    return convex_hull_image(ndim.binary_fill_holes(roi > 0))

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -70,10 +70,8 @@ if not op.exists('dti_streamlines.trk'):
     for bundle in bundles:
         for idx, roi in enumerate(bundles[bundle]['ROIs']):
             if bundles[bundle]['rules'][idx]:
-                warped_roi = patch_up_roi(
-                    mapping.transform_inverse(
-                        roi.get_data().astype(np.float32),
-                        interpolation='linear') > 0)
+                warped_roi = patch_up_roi(mapping.transform_inverse(
+                roi.get_data().astype(np.float32), interpolation='linear'))
                 nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),
                          f"{bundle}_{idx+1}.nii.gz")
                 # Add voxels that aren't there yet:

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -95,7 +95,7 @@ print("Segmenting fiber groups...")
 segmentation = seg.Segmentation(return_idx=True,
                                 filter_by_endpoints=True)
 segmentation.segment(bundles,
-                     sft.streamlines,
+                     sft,
                      fdata=hardi_fdata,
                      fbval=hardi_fbval,
                      fbvec=hardi_fbvec,
@@ -115,9 +115,10 @@ for bundle in bundles:
 
     idx_in_global = fiber_groups[bundle]['idx'][idx_in_bundle]
 
-    sft = StatefulTractogram(
-        dtu.transform_tracking_output(new_fibers, img.affine),
-        img, Space.RASMM)
+    sft = StatefulTractogram(new_fibers.streamlines,
+                             img,
+                             Space.VOX)
+    sft.to_rasmm()
 
     save_tractogram(sft, f'./{bundle}_afq.trk',
                     bbox_valid_check=False)
@@ -126,8 +127,8 @@ for bundle in bundles:
 print("Extracting tract profiles...")
 for bundle in bundles:
     fig, ax = plt.subplots(1)
-    weights = gaussian_weights(fiber_groups[bundle]['sl'])
-    profile = afq_profile(FA_data, fiber_groups[bundle]['sl'],
+    weights = gaussian_weights(fiber_groups[bundle]['sl'].streamlines)
+    profile = afq_profile(FA_data, fiber_groups[bundle]['sl'].streamlines,
                           np.eye(4), weights=weights)
     ax.plot(profile)
     ax.set_title(bundle)

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -93,7 +93,7 @@ sft.to_vox()
 
 print("Segmenting fiber groups...")
 segmentation = seg.Segmentation(return_idx=True,
-                                filter_by_endpoints=True)
+                                filter_by_endpoints=False)
 segmentation.segment(bundles,
                      sft,
                      fdata=hardi_fdata,
@@ -119,16 +119,16 @@ for bundle in bundles:
                              img,
                              Space.VOX)
     sft.to_rasmm()
-
     save_tractogram(sft, f'./{bundle}_afq.trk',
                     bbox_valid_check=False)
 
 
 print("Extracting tract profiles...")
 for bundle in bundles:
+    sft = load_tractogram(f'./{bundle}_afq.trk', img, to_space=Space.VOX)
     fig, ax = plt.subplots(1)
-    weights = gaussian_weights(fiber_groups[bundle]['sl'].streamlines)
-    profile = afq_profile(FA_data, fiber_groups[bundle]['sl'].streamlines,
+    weights = gaussian_weights(sft.streamlines)
+    profile = afq_profile(FA_data, sft.streamlines,
                           np.eye(4), weights=weights)
     ax.plot(profile)
     ax.set_title(bundle)

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -70,8 +70,11 @@ if not op.exists('dti_streamlines.trk'):
     for bundle in bundles:
         for idx, roi in enumerate(bundles[bundle]['ROIs']):
             if bundles[bundle]['rules'][idx]:
-                warped_roi = patch_up_roi(mapping.transform_inverse(
-                roi.get_data().astype(np.float32), interpolation='linear'))
+                warped_roi = patch_up_roi(
+                    mapping.transform_inverse(
+                        roi.get_data().astype(np.float32),
+                        interpolation='linear'))
+
                 nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),
                          f"{bundle}_{idx+1}.nii.gz")
                 # Add voxels that aren't there yet:


### PR DESCRIPTION
We should use StatefulTractogram methods for spatial transformations wherever possible (instead of `transform_tracking_output`).