### PR TITLE
`clean_by_endpoints` should be able to return the indices.

### DIFF
--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -800,7 +800,7 @@ def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None,
             endpoint_roi[atlas == targ] = 1
         idxes1 = np.array(np.where(endpoint_roi)).T
 
-    for sl in streamlines:
+    for ii, sl in enumerate(streamlines):
         if targets0 is None:
             # Nothing to check
             dist0ok = True
@@ -813,9 +813,15 @@ def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None,
         if dist0ok:
             if targets1 is None:
                 # Nothing to check on this end:
-                yield sl
+                if return_idx:
+                    yield sl, ii
+                else:
+                    yield sl
             else:
                 dist2 = np.min(cdist(np.array([sl[-1]]), idxes1,
                                      'sqeuclidean'))
                 if dist2 <= tol:
-                    yield sl
+                    if return_idx:
+                        yield sl, ii
+                    else:
+                        yield sl

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -542,7 +542,16 @@ class Segmentation:
                 select_sl = clean_by_endpoints(select_sl.streamlines,
                                                aal_idx[0],
                                                aal_idx[1],
-                                               tol=dist_to_aal)
+                                               tol=dist_to_aal,
+                                               return_idx=self.return_idx)
+                if self.return_idx:
+                    temp_select_sl = []
+                    temp_select_idx = []
+                    for ss in select_sl:
+                        temp_select_sl.append(ss[0])
+                        temp_select_idx.append(ss[1])
+                    select_idx = select_idx[temp_select_idx]
+                    select_sl = temp_select_sl
                 # Generate immediately:
                 select_sl = StatefulTractogram(select_sl,
                                                self.img,

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -731,7 +731,8 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=5,
         return out
 
 
-def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None):
+def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None,
+                       return_idx=False):
     """
     Clean a collection of streamlines based on their two endpoints
 

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -568,7 +568,7 @@ class Segmentation:
                         temp_select_sl.append(ss[0])
                         temp_select_idx[ii] = ss[1]
                     select_idx = select_idx[0][temp_select_idx]
-                    select_sl = temp_select_sl
+                    new_select_sl = temp_select_sl
 
                 select_sl = StatefulTractogram(new_select_sl,
                                                self.img,

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -181,9 +181,14 @@ def test_clean_by_endpoints():
     clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:2])
 
-    clean_sl, clean_idx = seg.clean_by_endpoints(
-        sl, [1, 2], [3, 4], atlas=atlas, return_idx=True)
+    clean_results = list(seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas, return_idx=True))
+    clean_idx = []
+    clean_sl = []
+    for res in clean_results:
+        clean_sl.append(res[0])
+        clean_idx.append(res[1])
     npt.assert_equal(list(clean_sl), sl[:2])
+
     npt.assert_equal(clean_idx, np.array([0, 1]))
 
 

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -181,7 +181,9 @@ def test_clean_by_endpoints():
     clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:2])
 
-    clean_results = list(seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas, return_idx=True))
+    clean_results = list(seg.clean_by_endpoints(sl, [1, 2], [3, 4],
+                                                atlas=atlas,
+                                                return_idx=True))
     clean_idx = []
     clean_sl = []
     for res in clean_results:

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -188,7 +188,6 @@ def test_clean_by_endpoints():
         clean_sl.append(res[0])
         clean_idx.append(res[1])
     npt.assert_equal(list(clean_sl), sl[:2])
-
     npt.assert_equal(clean_idx, np.array([0, 1]))
 
 

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -181,6 +181,12 @@ def test_clean_by_endpoints():
     clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:2])
 
+    clean_sl, clean_idx = seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], atlas=atlas, return_idx=True)
+    npt.assert_equal(list(clean_sl), sl[:2])
+    npt.assert_equal(clean_idx, np.array([0, 1]))
+
+
     # If tol=1, the third streamline also gets included
     clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], tol=1, atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:3])

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -15,16 +15,12 @@ import numpy as np
 import nibabel as nib
 import dipy.data as dpd
 from dipy.data import fetcher
-import dipy.tracking.utils as dtu
-import dipy.tracking.streamline as dts
 from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
 
 from AFQ import api
-import AFQ.utils.streamlines as aus
-import AFQ.data as afd
 import AFQ.tractography as aft
 import AFQ.registration as reg
 import AFQ.dti as dti


### PR DESCRIPTION
For now, just the failing unit test. Implementation to follow.