### PR TITLE
Read the MNI template from templateflow, instead of DIPY.

### DIFF
--- a/AFQ/__init__.py
+++ b/AFQ/__init__.py
@@ -1,6 +1,3 @@
-from .data import *  # noqa
-from .utils import *  # noqa
-from .api import *  # noqa
 from .version import version as __version__  # noqa
 
 _ga_id = "UA-156363454-3"

--- a/AFQ/__init__.py
+++ b/AFQ/__init__.py
@@ -1,3 +1,6 @@
+from .data import *  # noqa
+from .utils import *  # noqa
+from .api import *  # noqa
 from .version import version as __version__  # noqa
 
 _ga_id = "UA-156363454-3"

--- a/AFQ/__init__.py
+++ b/AFQ/__init__.py
@@ -1,6 +1,6 @@
-from .api import *  # noqa
 from .data import *  # noqa
 from .utils import *  # noqa
+from .api import *  # noqa
 from .version import version as __version__  # noqa
 
 _ga_id = "UA-156363454-3"

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -18,7 +18,7 @@ from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.stats.analysis import afq_profile
 
-import AFQ.data as afd
+from AFQ.data import read_mni_template
 from AFQ.dti import _fit as dti_fit
 from AFQ.csd import _fit as csd_fit
 import AFQ.tractography as aft
@@ -298,7 +298,7 @@ class AFQ(object):
         self.clean_params = default_clean_params
 
         if reg_template is None:
-            self.reg_template = afd.read_mni_template()
+            self.reg_template = read_mni_template()
         else:
             if not isinstance(reg_template, nib.Nifti1Image):
                 reg_template = nib.load(reg_template)
@@ -530,7 +530,7 @@ class AFQ(object):
             row, '_prealign_from-DWI_to-MNI_xfm.npy')
         if self.force_recompute or not op.exists(prealign_file):
             moving = nib.load(self._b0(row))
-            static = afd.read_mni_template()
+            static = read_mni_template()
             moving_data = moving.get_fdata()
             moving_affine = moving.affine
             static_data = static.get_fdata()

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -299,7 +299,7 @@ class AFQ(object):
         self.clean_params = default_clean_params
 
         if reg_template is None:
-            self.reg_template = dpd.read_mni_template()
+            self.reg_template = afd.read_mni_template()
         else:
             if not isinstance(reg_template, nib.Nifti1Image):
                 reg_template = nib.load(reg_template)
@@ -531,7 +531,7 @@ class AFQ(object):
             row, '_prealign_from-DWI_to-MNI_xfm.npy')
         if self.force_recompute or not op.exists(prealign_file):
             moving = nib.load(self._b0(row))
-            static = dpd.read_mni_template()
+            static = afd.read_mni_template()
             moving_data = moving.get_fdata()
             moving_affine = moving.affine
             static_data = static.get_fdata()

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -962,8 +962,8 @@ class AFQ(object):
                     afd.write_json(meta_fname, meta)
 
     def _export_bundle_gif(self, row):
-        bundles_file = self.get_clean_bundles()[0]
-        fa_file = self.get_dti_fa()[0]
+        bundles_file = self._clean_bundles(row)
+        fa_file = self._dti_fa(row)
         fa_img = nib.load(fa_file).get_fdata()
 
         scene = viz.visualize_volume(fa_img,
@@ -991,10 +991,10 @@ class AFQ(object):
         viz.create_gif(scene, fname)
 
     def _export_ROI_gifs(self, row):
-        bundles_file = self.get_clean_bundles()[0]
-        fa_file = self.get_dti_fa()[0]
+        bundles_file = self._clean_bundles(row)
+        fa_file = self._dti_fa(row)
         fa_img = nib.load(fa_file).get_fdata()
-        seg_img = nib.load(row['seg_file'])
+        seg_img = nib.load(self._wm_mask(row))
         dwi_img = nib.load(row['dwi_file'])
         dwi_data = dwi_img.get_fdata()
 
@@ -1017,7 +1017,8 @@ class AFQ(object):
                     interact=False,
                     scene=scene)
             except ValueError:
-                print("No streamlines found for " + bundle_name)
+                self.logger.info("No streamlines found to visualize for "
+                                 + bundle_name)
 
             for roi in self.bundle_dict[bundle_name]['ROIs']:
                 scene = viz.visualize_roi(

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -18,7 +18,7 @@ from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.stats.analysis import afq_profile
 
-from AFQ.data import read_mni_template
+import AFQ.data as afd
 from AFQ.dti import _fit as dti_fit
 from AFQ.csd import _fit as csd_fit
 import AFQ.tractography as aft
@@ -298,7 +298,7 @@ class AFQ(object):
         self.clean_params = default_clean_params
 
         if reg_template is None:
-            self.reg_template = read_mni_template()
+            self.reg_template = afd.read_mni_template()
         else:
             if not isinstance(reg_template, nib.Nifti1Image):
                 reg_template = nib.load(reg_template)
@@ -530,7 +530,7 @@ class AFQ(object):
             row, '_prealign_from-DWI_to-MNI_xfm.npy')
         if self.force_recompute or not op.exists(prealign_file):
             moving = nib.load(self._b0(row))
-            static = read_mni_template()
+            static = afd.read_mni_template()
             moving_data = moving.get_fdata()
             moving_affine = moving.affine
             static_data = static.get_fdata()

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -13,7 +13,6 @@ from scipy.ndimage.morphology import binary_dilation
 
 import dipy.core.gradients as dpg
 from dipy.segment.mask import median_otsu
-import dipy.data as dpd
 import dipy.tracking.utils as dtu
 from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -870,7 +870,7 @@ def s3fs_json_write(data, fname, fs=None):
         json.dump(data, ff)
 
 
-def read_mni_template(resolution=2, mask=True):
+def read_mni_template(resolution=1, mask=True):
     """
 
     Reads the MNI T2w template
@@ -878,7 +878,7 @@ def read_mni_template(resolution=2, mask=True):
     Parameters
     ----------
     resolution : int, optional.
-        Either 1 or 2, the resolution in mm of the voxels. Default: 2.
+        Either 1 or 2, the resolution in mm of the voxels. Default: 1.
 
     mask : bool, optional
         Whether to mask the data with a brain-mask before returning the image.

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -529,8 +529,8 @@ fetch_aal_atlas = _make_fetcher(
     "fetch_aal_atlas",
     op.join(afq_home,
             'aal_atlas'),
-    'https://digital.lib.washington.edu' + '/researchworks' +
-    '/bitstream/handle/1773/44951/',
+    'https://digital.lib.washington.edu' + '/researchworks'
+    + '/bitstream/handle/1773/44951/',
     ["MNI_AAL_AndMore.nii.gz",
      "MNI_AAL.txt"],
     ["MNI_AAL_AndMore.nii.gz",

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -903,6 +903,6 @@ def read_mni_template(resolution=1, mask=True):
                                           suffix='mask')))
 
         template_data = template_img.get_fdata()
-        mask_data = mask_img.get_fdata()
-        # out_data = template_data * mask_data
+        # mask_data = mask_img.get_fdata()
+        out_data = template_data  # * mask_data
         return nib.Nifti1Image(out_data, template_img.affine)

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -903,6 +903,6 @@ def read_mni_template(resolution=1, mask=True):
                                           suffix='mask')))
 
         template_data = template_img.get_fdata()
-        # mask_data = mask_img.get_fdata()
-        out_data = template_data  # * mask_data
+        mask_data = mask_img.get_fdata()
+        out_data = template_data * mask_data
         return nib.Nifti1Image(out_data, template_img.affine)

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -895,7 +895,7 @@ def read_mni_template(resolution=1, mask=True):
                                           suffix='T2w',
                                           extension='nii.gz')))
     if not mask:
-        return template
+        return template_img
     else:
         mask_img = nib.load(str(tflow.get('MNI152NLin2009cAsym',
                                           resolution=resolution,
@@ -904,5 +904,5 @@ def read_mni_template(resolution=1, mask=True):
 
         template_data = template_img.get_fdata()
         mask_data = mask_img.get_fdata()
-        out_data = template_data * mask_data
+        # out_data = template_data * mask_data
         return nib.Nifti1Image(out_data, template_img.affine)

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -529,7 +529,7 @@ fetch_aal_atlas = _make_fetcher(
     "fetch_aal_atlas",
     op.join(afq_home,
             'aal_atlas'),
-    'https://digital.lib.washington.edu' + '/researchworks' + \
+    'https://digital.lib.washington.edu' + '/researchworks' +
     '/bitstream/handle/1773/44951/',
     ["MNI_AAL_AndMore.nii.gz",
      "MNI_AAL.txt"],
@@ -870,30 +870,39 @@ def s3fs_json_write(data, fname, fs=None):
         json.dump(data, ff)
 
 
-def read_mni_template(res=resolution, mask=True):
+def read_mni_template(resolution=2, mask=True):
     """
 
-    Reads that MNI T2w template
+    Reads the MNI T2w template
 
+    Parameters
+    ----------
+    resolution : int, optional.
+        Either 1 or 2, the resolution in mm of the voxels. Default: 2.
+
+    mask : bool, optional
+        Whether to mask the data with a brain-mask before returning the image.
+        Default : True
+
+    Returns
+    -------
+    nib.Nifti1Image class instance containing masked or unmasked T2 template.
 
     """
     template_img = nib.load(tflow.get('MNI152NLin2009cAsym',
                                       desc=None,
                                       resolution=resolution,
                                       suffix='T2w',
-                                      extension='nii.gz')
+                                      extension='nii.gz'))
     if not mask:
         return template
     else:
         mask_img = nib.load(tflow.get('MNI152NLin2009cAsym',
-                                     resolution=resolution,
-                                     desc='brain',
-                                     suffix='mask'))
+                                      resolution=resolution,
+                                      desc='brain',
+                                      suffix='mask'))
 
         template_data = template_img.get_fdata()
         mask_data = mask_img.get_fdata()
         out_data = template_data * mask_data
         return nib.Nifti1Image(out_data, template_img.affine)
-
-
-

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 import nibabel as nib
+from templateflow import api as tflow
 import dipy.data as dpd
 from dipy.data.fetcher import _make_fetcher
 from dipy.io.streamline import load_tractogram, load_trk
@@ -867,3 +868,32 @@ def s3fs_json_write(data, fname, fs=None):
         fs = s3fs.S3FileSystem()
     with fs.open(fname, 'w') as ff:
         json.dump(data, ff)
+
+
+def read_mni_template(res=resolution, mask=True):
+    """
+
+    Reads that MNI T2w template
+
+
+    """
+    template_img = nib.load(tflow.get('MNI152NLin2009cAsym',
+                                      desc=None,
+                                      resolution=resolution,
+                                      suffix='T2w',
+                                      extension='nii.gz')
+    if not mask:
+        return template
+    else:
+        mask_img = nib.load(tflow.get('MNI152NLin2009cAsym',
+                                     resolution=resolution,
+                                     desc='brain',
+                                     suffix='mask'))
+
+        template_data = template_img.get_fdata()
+        mask_data = mask_img.get_fdata()
+        out_data = template_data * mask_data
+        return nib.Nifti1Image(out_data, template_img.affine)
+
+
+

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -889,18 +889,18 @@ def read_mni_template(resolution=2, mask=True):
     nib.Nifti1Image class instance containing masked or unmasked T2 template.
 
     """
-    template_img = nib.load(tflow.get('MNI152NLin2009cAsym',
-                                      desc=None,
-                                      resolution=resolution,
-                                      suffix='T2w',
-                                      extension='nii.gz'))
+    template_img = nib.load(str(tflow.get('MNI152NLin2009cAsym',
+                                          desc=None,
+                                          resolution=resolution,
+                                          suffix='T2w',
+                                          extension='nii.gz')))
     if not mask:
         return template
     else:
-        mask_img = nib.load(tflow.get('MNI152NLin2009cAsym',
-                                      resolution=resolution,
-                                      desc='brain',
-                                      suffix='mask'))
+        mask_img = nib.load(str(tflow.get('MNI152NLin2009cAsym',
+                                          resolution=resolution,
+                                          desc='brain',
+                                          suffix='mask')))
 
         template_data = template_img.get_fdata()
         mask_data = mask_img.get_fdata()

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -117,7 +117,7 @@ def syn_register_dwi(dwi, gtab, template=None, **syn_kwargs):
     DiffeomorphicMap object
     """
     if template is None:
-        template = dpd.read_mni_template()
+        template = afd.read_mni_template()
     if isinstance(template, str):
         template = nib.load(template)
 

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -27,7 +27,6 @@ from dipy.io.streamline import load_tractogram, load_trk
 
 import AFQ.utils.models as mut
 import AFQ.utils.streamlines as sut
-import AFQ.data as afd
 
 syn_metric_dict = {'CC': CCMetric,
                    'EM': EMMetric,
@@ -118,6 +117,7 @@ def syn_register_dwi(dwi, gtab, template=None, **syn_kwargs):
     DiffeomorphicMap object
     """
     if template is None:
+        import AFQ.data as afd
         template = afd.read_mni_template()
     if isinstance(template, str):
         template = nib.load(template)

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -27,6 +27,7 @@ from dipy.io.streamline import load_tractogram, load_trk
 
 import AFQ.utils.models as mut
 import AFQ.utils.streamlines as sut
+import AFQ.data as afd
 
 syn_metric_dict = {'CC': CCMetric,
                    'EM': EMMetric,

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -6,7 +6,10 @@ from scipy.spatial.distance import cdist
 from scipy.stats import zscore
 
 import nibabel as nib
+from templateflow import api as tflow
+
 from tqdm.auto import tqdm
+
 
 import dipy.data as dpd
 import dipy.tracking.streamline as dts
@@ -250,7 +253,7 @@ class Segmentation:
             Default: None.
         """
         if reg_template is None:
-            reg_template = dpd.read_mni_template()
+            reg_template = afd.read_mni_template()
 
         self.reg_template = reg_template
 

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -259,7 +259,8 @@ class Segmentation:
 
         if mapping is None:
             gtab = dpg.gradient_table(self.fbval, self.fbvec)
-            self.mapping = reg.syn_register_dwi(self.fdata, gtab)[1]
+            self.mapping = reg.syn_register_dwi(self.fdata, gtab,
+                                                template=reg_template)[1]
         elif isinstance(mapping, str) or isinstance(mapping, nib.Nifti1Image):
             if reg_prealign is None:
                 reg_prealign = np.eye(4)

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -158,7 +158,7 @@ def test_AFQ_data_waypoint():
     tgram = load_tractogram(myafq.bundles[0], myafq.dwi_img[0])
 
     bundles = aus.tgram_to_bundles(tgram, myafq.bundle_dict, myafq.dwi_img[0])
-    npt.assert_(len(bundles['CST_L']) > 0)
+    npt.assert_(len(bundles['CST_R']) > 0)
 
     # Test ROI exporting:
     myafq.export_rois()

--- a/AFQ/tests/test_registration.py
+++ b/AFQ/tests/test_registration.py
@@ -18,7 +18,7 @@ from dipy.tracking.utils import transform_tracking_output
 from dipy.io.streamline import load_trk, save_trk
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 
-MNI_T2 = dpd.read_mni_template()
+MNI_T2 = afd.read_mni_template()
 hardi_img, gtab = dpd.read_stanford_hardi()
 MNI_T2_data = MNI_T2.get_fdata()
 MNI_T2_affine = MNI_T2.affine

--- a/AFQ/tests/test_registration.py
+++ b/AFQ/tests/test_registration.py
@@ -14,6 +14,8 @@ from AFQ.registration import (syn_registration, register_series, register_dwi,
                               streamline_registration, write_mapping,
                               read_mapping, syn_register_dwi, DiffeomorphicMap)
 
+import AFQ.data as afd
+
 from dipy.tracking.utils import transform_tracking_output
 from dipy.io.streamline import load_trk, save_trk
 from dipy.io.stateful_tractogram import StatefulTractogram, Space

--- a/examples/plot_recobundles.py
+++ b/examples/plot_recobundles.py
@@ -55,7 +55,7 @@ FA_img = nib.load(dti_params['FA'])
 FA_data = FA_img.get_fdata()
 
 print("Registering to template...")
-MNI_T2_img = dpd.read_mni_template()
+MNI_T2_img = afd.read_mni_template()
 if not op.exists('mapping.nii.gz'):
     import dipy.core.gradients as dpg
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -73,7 +73,7 @@ FA_data = FA_img.get_fdata()
 #     CLI.
 #
 print("Registering to template...")
-MNI_T2_img = dpd.read_mni_template()
+MNI_T2_img = afd.read_mni_template()
 if not op.exists('mapping.nii.gz'):
     import dipy.core.gradients as dpg
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -21,6 +21,7 @@ from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
 
 from AFQ import api
+import AFQ.data as afd
 import AFQ.tractography as aft
 import AFQ.registration as reg
 import AFQ.dti as dti

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ popylar==0.2
 fury==0.4.0
 imageio==2.8.0
 ipython==7.13.0
-
+templateflow==0.4.2


### PR DESCRIPTION
This has the added benefit that we can get a brainmask for our registration from the same place (which is the default behavior implemented here).