### PR TITLE
Fix warping

### DIFF
--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -310,7 +310,7 @@ class Segmentation:
                 roi = roi.get_fdata()
             warped_roi = auv.patch_up_roi(self.mapping.transform_inverse(
                 roi.astype(np.float32), interpolation='linear'))
-
+ 
             if rule:
                 # include ROI:
                 include_rois.append(np.array(np.where(warped_roi)).T)


### PR DESCRIPTION
Hi, 
this fix corrects the warping of ROI and probability maps in segmentation.py. It had been done with using the forward direction of the warp operation used to warp native on template. Now it is done with the inverse, resulting in ROI and probmap, which were previously registered to template, being warped into native space. 
Also, added debugging lines, which are currently commented-out, in preparation for an optional debugging feature mode that allows step by step tracking of problems with image registration.
_aNNe