### PR TITLE
swap the endpoint assignment

### DIFF
--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -832,7 +832,7 @@ def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None,
             dist0ok = True
         else:
             dist0ok = False
-            dist0 = np.min(cdist(np.array([sl[0]]), idxes0, 'sqeuclidean'))
+            dist0 = np.min(cdist(np.array([sl[-1]]), idxes0, 'sqeuclidean'))
             if dist0 <= tol:
                 dist0ok = True
         # Only proceed if conditions for one side are fulfilled:
@@ -844,7 +844,7 @@ def clean_by_endpoints(streamlines, targets0, targets1, tol=None, atlas=None,
                 else:
                     yield sl
             else:
-                dist2 = np.min(cdist(np.array([sl[-1]]), idxes1,
+                dist2 = np.min(cdist(np.array([sl[0]]), idxes1,
                                      'sqeuclidean'))
                 if dist2 <= tol:
                     if return_idx:


### PR DESCRIPTION
assignment of streamline begin to cortical target0 and streamline end to cortical target1 did not result in valid streamlines in our data for ATR. Swapping did. 
This has been briefly tested for a few other tracts, but I am far from sure that this change is valid for all. In fact, I believe that the assignment should be tested routinely as part of the debug-mode: distances between zero end and both cortical target and distances of -1 end and both targets are recorded and if the distribution of distances is clearly different, and does not follow the expected order , the user should be notified to arrange the targets (or rois) in a different sequence.