### PR TITLE
BF: Use Tableau 20 colors for the 20 waypoint-defined bundles.

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1030,9 +1030,10 @@ class AFQ(object):
         scene = viz.visualize_volume(fa_img,
                                      inline=False,
                                      interact=False)
+
         scene = viz.visualize_bundles(bundles_file,
-                                      affine_or_mapping=row['dwi_affine'],
-                                      bundle_names=self.bundle_dict,
+                                      affine=row['dwi_affine'],
+                                      bundle_dict=self.bundle_dict,
                                       inline=False,
                                       interact=False,
                                       scene=scene)
@@ -1071,8 +1072,8 @@ class AFQ(object):
             try:
                 scene = viz.visualize_bundles(
                     bundles_file,
-                    affine_or_mapping=row['dwi_affine'],
-                    bundle_names=self.bundle_dict,
+                    affine=row['dwi_affine'],
+                    bundle_dict=self.bundle_dict,
                     bundle=uid,
                     inline=False,
                     interact=False,

--- a/AFQ/viz.py
+++ b/AFQ/viz.py
@@ -57,7 +57,8 @@ def _inline_interact(scene, inline, interact):
 
 
 def visualize_bundles(trk, affine=None, bundle_dict=None, bundle=None,
-                      colors=None, scene=None, interact=False, inline=False):
+                      colors=None, scene=None, background=(1, 1, 1),
+                      interact=False, inline=False):
     """
     Visualize bundles in 3D using VTK
 
@@ -83,7 +84,11 @@ def visualize_bundles(trk, affine=None, bundle_dict=None, bundle=None,
     colors : dict or list
         If this is a dict, keys are bundle names and values are RGB tuples.
         If this is a list, each item is an RGB tuple. Defaults to a list
-        with Tableua 20 RGB values
+        with Tableau 20 RGB values
+
+    background : tuple, optional
+        RGB values for the background. Default: (1, 1, 1), which is white
+        background.
 
     scene : fury Scene object, optional
         If provided, the visualization will be added to this Scene. Default:
@@ -115,6 +120,8 @@ def visualize_bundles(trk, affine=None, bundle_dict=None, bundle=None,
 
     if scene is None:
         scene = window.Scene()
+
+    scene.SetBackground(background[0], background[1], background[2])
 
     if colors is None:
         # Use the color dict provided


### PR DESCRIPTION
Fixes #247

It turns out that we don't need 40 colors. This is only needed in AFQ-Browser
because we need to be able to highlight the picked bundles.

This means that the code can be simplified quite a bit. This commit also
clarifies and simplifies the logic, including comments. And adds a docstring.

Changes in the API module to remain consistent.
