### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.maintenance/update_zenodo.py
+++ b/.maintenance/update_zenodo.py
@@ -11,7 +11,7 @@ import sys
 import shutil
 from pathlib import Path
 import json
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 import subprocess as sp
 
 # These ORCIDs should go last
@@ -53,12 +53,11 @@ if __name__ == '__main__':
     name_matches = []
     position = 1
     for ele in data:
-        matches = process.extract(ele, zen_names, scorer=fuzz.token_sort_ratio,
-                                  limit=2)
-        # matches is a list:
-        # [('First match', % Match), ('Second match', % Match)]
-        if matches[0][1] > 80:
-            val = zenodo['creators'][zen_names.index(matches[0][0])]
+        match = process.extractOne(ele, zen_names, scorer=fuzz.token_sort_ratio,
+                                  score_cutoff=80)
+
+        if match:
+            val = zenodo['creators'][zen_names.index(match[0])]
         else:
             # skip unmatched names
             print("No entry to sort:", ele)

--- a/.maintenance/update_zenodo.py
+++ b/.maintenance/update_zenodo.py
@@ -53,8 +53,9 @@ if __name__ == '__main__':
     name_matches = []
     position = 1
     for ele in data:
-        match = process.extractOne(ele, zen_names, scorer=fuzz.token_sort_ratio,
-                                  score_cutoff=80)
+        match = process.extractOne(ele, zen_names,
+                                   scorer=fuzz.token_sort_ratio,
+                                   score_cutoff=80)
 
         if match:
             val = zenodo['creators'][zen_names.index(match[0])]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ sphinx_rtd_theme
 numpydoc
 sphinx-autoapi
 six==1.12.0
-fuzzywuzzy
+rapidfuzz
 xvfbwrapper


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy