### PR TITLE
Fixed numpydoc version to 0.9.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-cov==2.8.1
 flake8
 sphinx_gallery
 sphinx_rtd_theme
-numpydoc
+numpydoc==0.9.2
 sphinx-autoapi
 six==1.12.0
 fuzzywuzzy


### PR DESCRIPTION
The numpydoc version 1.0.0 causes the error:
`Handler <function mangle_docstrings at 0x1124e5400> for event 'autodoc-process-docstring' threw an exception`
In our documentation tests. I am not sure why.