### PR TITLE
Kaleido instead of orcas

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1185,7 +1185,7 @@ class AFQ(object):
                         include_seg=True))
 
                 fname = op.join(fname[0], roi_dir, fname[1])
-                self.viz.create_gif(figure, fname, creating_many=True)
+                self.viz.create_gif(figure, fname)
             if export_as_html:
                 roi_dir = op.join(row['results_dir'], 'viz_bundles')
                 os.makedirs(roi_dir, exist_ok=True)
@@ -1204,9 +1204,6 @@ class AFQ(object):
 
                 fname = op.join(fname[0], roi_dir, fname[1])
                 figure.write_html(fname)
-
-        if export_as_gif:
-            self.viz.stop_creating_gifs()
 
     def _plot_tract_profiles(self, row):
         tract_profiles = pd.read_csv(self.get_tract_profiles()[0])

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1490,15 +1490,16 @@ class AFQ(object):
                     xform_color_by_volume=False,
                     inline=False,
                     interactive=False):
-        self.data_frame.apply(self._viz_bundles, axis=1,
-                              export_as_gif=export_as_gif,
-                              export_as_html=export_as_html,
-                              volume=volume,
-                              xform_volume=xform_volume,
-                              color_by_volume=color_by_volume,
-                              xform_color_by_volume=xform_color_by_volume,
-                              inline=inline,
-                              interactive=interactive)
+        return self.data_frame.apply(
+            self._viz_bundles, axis=1,
+            export_as_gif=export_as_gif,
+            export_as_html=export_as_html,
+            volume=volume,
+            xform_volume=xform_volume,
+            color_by_volume=color_by_volume,
+            xform_color_by_volume=xform_color_by_volume,
+            inline=inline,
+            interactive=interactive)
 
     def viz_ROIs(self,
                  bundle_names=None,

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -113,16 +113,11 @@ def scene_rotate_forward(scene):
     return scene
 
 
-def stop_creating_gifs():
-    pass
-
-
 def create_gif(figure,
                file_name,
                n_frames=60,
                zoom=1,
                z_offset=0.5,
-               creating_many=False,
                size=(600, 600),
                rotate_forward=True):
     """
@@ -144,11 +139,6 @@ def create_gif(figure,
     zoom: int, optional
         How much to magnify the figure in the fig.
         Default: 1
-
-    creating_many: bool, optional
-        Whether or not you intend to repeatedly call this function.
-        Can speed up performance when using plotly.
-        Default: False
 
     size: tuple, optional
         Size of the gif.

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -203,26 +203,11 @@ def visualize_bundles(sft, affine=None, bundle_dict=None, bundle=None,
     return _inline_interact(figure, interact, inline)
 
 
-def stop_creating_gifs():
-    try:
-        plotly.io.orca.shutdown_server()
-    except ValueError:
-        ValueError(_orca_err())
-
-
-def _orca_err():
-    return ("pyAFQ is trying to generate gifs using plotly. "
-            + "This requires orca, which cannot be installed via pip. "
-            + "See: https://github.com/plotly/orca \n"
-            + "Or consider using fury to visualize with pyAFQ instead")
-
-
 def create_gif(figure,
                file_name,
                n_frames=60,
                zoom=2.5,
                z_offset=0.5,
-               creating_many=False,
                size=(600, 600)):
     """
     Convert a Plotly Figure object into a gif
@@ -244,11 +229,6 @@ def create_gif(figure,
         How much to magnify the figure in the fig.
         Default: 2.5
 
-    creating_many: bool, optional
-        Whether or not you intend to repeatedly call this function.
-        Can speed up performance when using plotly.
-        Default: False
-
     size: tuple, optional
         Size of the gif.
         Default: (600, 600)
@@ -262,13 +242,7 @@ def create_gif(figure,
                      y=np.sin(theta) * zoom, z=z_offset)
         )
         figure.update_layout(scene_camera=camera)
-        try:
-            figure.write_image(tdir + f"/tgif{i}.png")
-        except ValueError:
-            ValueError(_orca_err())
-
-    if not creating_many:
-        stop_creating_gifs()
+        figure.write_image(tdir + f"/tgif{i}.png")
 
     vut.gif_from_pngs(tdir, file_name, n_frames,
                       png_fname="tgif", add_zeros=False)

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -336,7 +336,6 @@ class Viz:
             self.visualize_roi = AFQ.viz.fury_backend.visualize_roi
             self.visualize_volume = AFQ.viz.fury_backend.visualize_volume
             self.create_gif = AFQ.viz.fury_backend.create_gif
-            self.stop_creating_gifs = AFQ.viz.fury_backend.stop_creating_gifs
         elif backend == "plotly":
             try:
                 import AFQ.viz.plotly_backend
@@ -346,8 +345,6 @@ class Viz:
             self.visualize_roi = AFQ.viz.plotly_backend.visualize_roi
             self.visualize_volume = AFQ.viz.plotly_backend.visualize_volume
             self.create_gif = AFQ.viz.plotly_backend.create_gif
-            self.stop_creating_gifs = \
-                AFQ.viz.plotly_backend.stop_creating_gifs
 
 
 def visualize_tract_profiles(tract_profiles, scalar="dti_fa", min_fa=0.0,

--- a/requirements-plotly.txt
+++ b/requirements-plotly.txt
@@ -1,2 +1,3 @@
 plotly==4.8.2
 psutil==5.7.0
+kaleido

--- a/requirements-plotly.txt
+++ b/requirements-plotly.txt
@@ -1,3 +1,3 @@
-plotly==4.8.2
+plotly==4.9.0
 psutil==5.7.0
 kaleido


### PR DESCRIPTION
This allows plotly to export static images such as gifs without any complicated installs.

@arokem if this passes the tests, it should be ready to merge.

Closes #304 