### PR TITLE
Remove this section of the pyproject.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-write_to = "AFQ/version.py"


### PR DESCRIPTION
The hope is that the local version will be picked up from setup.py instead.

This should resolve the current breakage on master.