### PR TITLE
S3 Bids Fetch Fixes

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1056,7 +1056,6 @@ class S3BIDSStudy:
 
     def download(self, directory,
                  include_modality_agnostic=("dataset_description.json",),
-                 include_dataset_description=True,
                  include_derivs=False, overwrite=False, pbar=True):
         """Download files for each subject in the study
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1051,6 +1051,7 @@ class S3BIDSStudy:
         fs = s3fs.S3FileSystem(anon=self.anon)
         for fn in self.non_sub_s3_keys['raw']:
             if select == "all" or any([s in fn for s in select]):
+                Path(directory).mkdir(parents=True, exist_ok=True)
                 fs.get(fn, op.join(directory, op.basename(fn)))
 
     def download(self, directory,

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -717,8 +717,7 @@ class HBNSubject(S3BIDSSubject):
 
         super().__init__(
             subject_id=subject_id,
-            study=study,
-            site=site
+            study=study
         )
 
     @property

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -966,9 +966,10 @@ class S3BIDSStudy:
         s3_prefix = '/'.join([self.bucket, self.s3_prefix])
         nonsub_keys = _ls_s3fs(s3_prefix=s3_prefix,
                                anon=self.anon)['other']
-        if 'derivatives' in nonsub_keys:
+        derivatives_prefix = '/'.join([s3_prefix, 'derivatives'])
+        if derivatives_prefix in nonsub_keys:
             return _ls_s3fs(
-                s3_prefix='/'.join([s3_prefix, 'derivatives']),
+                s3_prefix=derivatives_prefix,
                 anon=self.anon
             )['other']
         else:
@@ -1212,10 +1213,11 @@ class HBNSite(S3BIDSStudy):
         s3_prefix = '/'.join([self.bucket, self.s3_prefix])
         nonsub_keys = _ls_s3fs(s3_prefix=s3_prefix,
                                anon=self.anon)['other']
+        derivatives_prefix = '/'.join([s3_prefix, 'derivatives'])
 
-        if any(['derivatives' in key for key in nonsub_keys]):
+        if any([derivatives_prefix in key for key in nonsub_keys]):
             deriv_subs = _ls_s3fs(
-                s3_prefix='/'.join([s3_prefix, 'derivatives']),
+                s3_prefix=derivatives_prefix,
                 anon=self.anon
             )['subjects']
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -533,9 +533,7 @@ class S3BIDSSubject:
                              self.subject_id]).lstrip('/'),
             'derivatives': {
                 dt: '/'.join([
-                    self.study.s3_prefix,
-                    'derivatives',
-                    dt,
+                    *dt.split('/')[1:],  # removes bucket name
                     self.subject_id
                 ]).lstrip('/') for dt in self.study.derivative_types
             },
@@ -998,15 +996,8 @@ class S3BIDSStudy:
 
         nonsub_deriv_keys = []
         for dt in self.derivative_types:
-            s3_prefix = '/'.join([
-                self.bucket,
-                self.s3_prefix,
-                'derivatives',
-                dt
-            ])
-
             nonsub_deriv_keys.append(_ls_s3fs(
-                s3_prefix=s3_prefix,
+                s3_prefix=dt,
                 anon=self.anon
             )['other'])
 


### PR DESCRIPTION
It seems to be working now. We made 3 fixes:

1. make directory for modality agnostic files if it does not exist
2. allow derivatives to download, which was broken before because the prefix was wrong
3. download the dataset description for derivatives by default whenever downloading a given derivative, if it exists