### PR TITLE
Allow for selecting subject(s) by position after randomization

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -877,7 +877,7 @@ class S3BIDSStudy:
             elif isinstance(subjects, int):
                 subjects = randomized_subjects[:subjects]
             else:
-                subjects = randomized_subjects[subjects]
+                subjects = [randomized_subjects[i] for i in subjects]
 
             if isinstance(subjects, str):
                 subjects = [subjects]

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -869,7 +869,7 @@ class S3BIDSStudy:
                     and isinstance(subjects[0], int)):
             # if subjects is an int, get that many random subjects
             prng = np.random.RandomState(random_seed)
-            randomized_subjects = self._all_subjects.copy()
+            randomized_subjects = sorted(self._all_subjects.copy())
             prng.shuffle(randomized_subjects)
 
             if subjects is None:

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -831,9 +831,10 @@ class S3BIDSStudy:
         if not (subjects is None
                 or isinstance(subjects, int)
                 or isinstance(subjects, str)
-                or all(isinstance(s, str) for s in subjects)):
-            raise TypeError('`subjects` must be an int, string or a '
-                            'sequence of strings.')
+                or all(isinstance(s, str) for s in subjects)
+                or all(isinstance(s, int) for s in subjects)):
+            raise TypeError('`subjects` must be an int, string, '
+                            'sequence of strings, or a sequence of ints.')
 
         if not isinstance(anon, bool):
             raise TypeError('`anon` must be of type bool.')


### PR DESCRIPTION
This will be useful with cloudknot. For example, imagine I want to use cloudknout to process 3 random subjects. Each process can use the same random seed, but be told to use either the first, second, or third subject out of the randomized list of subjects generated from the same seed.