### PR TITLE
Update to Dipy 1.2.0

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1083,7 +1083,7 @@ class AFQ(object):
                         row,
                         f'_desc-ROI-{bundle}-{ii + 1}-{inclusion}.nii.gz'))
 
-                fname = op.join(fname[0], rois_dir, fname[1])
+                fname = op.join(rois_dir, fname[1])
                 if not op.exists(fname):
 
                     warped_roi = auv.patch_up_roi(
@@ -1302,7 +1302,7 @@ class AFQ(object):
                             include_track=True,
                             include_seg=True))
 
-                    fname = op.join(fname[0], roi_dir, fname[1])
+                    fname = op.join(roi_dir, fname[1])
                     self.viz.create_gif(figure, fname)
                 else:
                     roi_dir = op.join(row['results_dir'], 'viz_bundles')
@@ -1315,7 +1315,7 @@ class AFQ(object):
                             include_track=True,
                             include_seg=True))
 
-                    fname = op.join(fname[0], roi_dir, fname[1])
+                    fname = op.join(roi_dir, fname[1])
                     figure.write_html(fname)
         row['timing']['Visualization'] =\
             row['timing']['Visualization'] + time() - start_time

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1130,7 +1130,7 @@ class AFQ(object):
                             f'_tractography.trk',
                             include_track=True,
                             include_seg=True))
-                    fname = op.join(fname[0], bundles_dir, fname[1])
+                    fname = op.join(bundles_dir, fname[1])
                     self.log_and_save_trk(this_tgm, fname)
                     meta = dict(source=bundles_file)
                     meta_fname = fname.split('.')[0] + '.json'

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -387,17 +387,9 @@ class Segmentation:
         dist = []
         for roi in include_rois:
             # Use squared Euclidean distance, because it's faster:
-            try:
-                dist.append(cdist(sl, roi, 'sqeuclidean'))
-                if np.min(dist[-1]) > tol:
-                    # Too far from one of them:
-                    return False, []
-            except ValueError:
-                self.logger.warning(
-                    "See if UserWarning: Input image is entirely zero has"
-                    + " been printed above. It is likely caused by an ROI"
-                    + " with no voxels. Possibly due to problems in"
-                    + " registration.")
+            dist.append(cdist(sl, roi, 'sqeuclidean'))
+            if np.min(dist[-1]) > tol:
+                # Too far from one of them:
                 return False, []
         # Apparently you checked all the ROIs and it was close to all of them
         return True, dist
@@ -408,15 +400,7 @@ class Segmentation:
         """
         for roi in exclude_rois:
             # Use squared Euclidean distance, because it's faster:
-            try:
-                if np.min(cdist(sl, roi, 'sqeuclidean')) < tol:
-                    return False
-            except ValueError:
-                self.logger.warning(
-                    "See if UserWarning: Input image is entirely zero has"
-                    + " been printed above. It is likely caused by an ROI"
-                    + " with no voxels. Possibly due to problems in"
-                    + " registration.")
+            if np.min(cdist(sl, roi, 'sqeuclidean')) < tol:
                 return False
         # Either there are no exclusion ROIs, or you are not close to any:
         return True

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -388,7 +388,7 @@ class Segmentation:
         for roi in include_rois:
             # Use squared Euclidean distance, because it's faster:
             dist.append(cdist(sl, roi, 'sqeuclidean'))
-            if np.min(dist[-1]) > tol:
+            if len(dist[-1]) < 0 or np.min(dist[-1]) > tol:
                 # Too far from one of them:
                 return False, []
         # Apparently you checked all the ROIs and it was close to all of them
@@ -400,7 +400,8 @@ class Segmentation:
         """
         for roi in exclude_rois:
             # Use squared Euclidean distance, because it's faster:
-            if np.min(cdist(sl, roi, 'sqeuclidean')) < tol:
+            dist = cdist(sl, roi, 'sqeuclidean')
+            if len(dist) < 0 or np.min(dist) < tol:
                 return False
         # Either there are no exclusion ROIs, or you are not close to any:
         return True

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -393,7 +393,11 @@ class Segmentation:
                     # Too far from one of them:
                     return False, []
             except ValueError:
-                self.logger.warning(f"Defective streamline found: {sl}")
+                self.logger.warning(
+                    "See if UserWarning: Input image is entirely zero has"
+                    + " been printed above. It is likely caused by an ROI"
+                    + " with no voxels. Possibly due to problems in"
+                    + " registration.")
                 return False, []
         # Apparently you checked all the ROIs and it was close to all of them
         return True, dist
@@ -408,7 +412,11 @@ class Segmentation:
                 if np.min(cdist(sl, roi, 'sqeuclidean')) < tol:
                     return False
             except ValueError:
-                self.logger.warning(f"Defective streamline found: {sl}")
+                self.logger.warning(
+                    "See if UserWarning: Input image is entirely zero has"
+                    + " been printed above. It is likely caused by an ROI"
+                    + " with no voxels. Possibly due to problems in"
+                    + " registration.")
                 return False
         # Either there are no exclusion ROIs, or you are not close to any:
         return True

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -388,7 +388,7 @@ class Segmentation:
         for roi in include_rois:
             # Use squared Euclidean distance, because it's faster:
             dist.append(cdist(sl, roi, 'sqeuclidean'))
-            if len(dist[-1]) < 0 or np.min(dist[-1]) > tol:
+            if len(dist[-1]) < 1 or np.min(dist[-1]) > tol:
                 # Too far from one of them:
                 return False, []
         # Apparently you checked all the ROIs and it was close to all of them
@@ -401,7 +401,7 @@ class Segmentation:
         for roi in exclude_rois:
             # Use squared Euclidean distance, because it's faster:
             dist = cdist(sl, roi, 'sqeuclidean')
-            if len(dist) < 0 or np.min(dist) < tol:
+            if len(dist) < 1 or np.min(dist) < tol:
                 return False
         # Either there are no exclusion ROIs, or you are not close to any:
         return True

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -387,9 +387,13 @@ class Segmentation:
         dist = []
         for roi in include_rois:
             # Use squared Euclidean distance, because it's faster:
-            dist.append(cdist(sl, roi, 'sqeuclidean'))
-            if len(dist[-1]) < 1 or np.min(dist[-1]) > tol:
-                # Too far from one of them:
+            try:
+                dist.append(cdist(sl, roi, 'sqeuclidean'))
+                if np.min(dist[-1]) > tol:
+                    # Too far from one of them:
+                    return False, []
+            except ValueError:
+                self.logger.warning(f"Defective streamline found: {sl}")
                 return False, []
         # Apparently you checked all the ROIs and it was close to all of them
         return True, dist
@@ -400,8 +404,11 @@ class Segmentation:
         """
         for roi in exclude_rois:
             # Use squared Euclidean distance, because it's faster:
-            dist = cdist(sl, roi, 'sqeuclidean')
-            if len(dist) < 1 or np.min(dist) < tol:
+            try:
+                if np.min(cdist(sl, roi, 'sqeuclidean')) < tol:
+                    return False
+            except ValueError:
+                self.logger.warning(f"Defective streamline found: {sl}")
                 return False
         # Either there are no exclusion ROIs, or you are not close to any:
         return True

--- a/AFQ/tests/test_bundles.py
+++ b/AFQ/tests/test_bundles.py
@@ -38,7 +38,7 @@ def test_bundles_class():
         bundles_og.save_bundles(file_path=tmpdir)
 
         # load bundles again
-        bundles = bdl.Bundles()
+        bundles = bdl.Bundles(reference=img)
         bundle_names = ['CST_L', 'CST_R']
         bundles.load_bundles(bundle_names, file_path=tmpdir)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.6
 install_requires =
     scikit_image==0.16.2
     nibabel==3.0.2
-    dipy@git+https://github.com/dipy/dipy.git@331429f05b22cb5b23d302b978915d41cbf04c91
+    dipy==1.2.0
     scipy>=1.2.0
     numpy==1.17.5
     pandas==1.0.3
@@ -49,9 +49,6 @@ install_requires =
     templateflow==0.6.2
     pybids==0.11.1
     funcargparse==0.2.2
-    cython>=0.29
-    h5py>=2.5.0
-    packaging>=19.0
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,7 @@ python_requires = >=3.6
 install_requires =
     scikit_image==0.16.2
     nibabel==3.0.2
-    dipy@https://github.com/dipy/dipy.git
-    #dipy==1.1.1
+    dipy@git+https://github.com/dipy/dipy.git@331429f05b22cb5b23d302b978915d41cbf04c91
     scipy>=1.2.0
     numpy==1.17.5
     pandas==1.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ python_requires = >=3.6
 install_requires =
     scikit_image==0.16.2
     nibabel==3.0.2
-    dipy==1.1.1
+    dipy@https://github.com/dipy/dipy.git
+    #dipy==1.1.1
     scipy>=1.2.0
     numpy==1.17.5
     pandas==1.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,9 @@ install_requires =
     templateflow==0.6.2
     pybids==0.11.1
     funcargparse==0.2.2
+    cython>=0.29
+    h5py>=2.5.0
+    packaging>=19.0
 zip_safe = False
 include_package_data = True
 packages = find:


### PR DESCRIPTION
The load_tractogram in dipy v1.1.1 uses srow to get the affine information from a reference. However, some files have affine stored in the q info (q offset, pixdim), not s. This is fixed in the current dipy master, where they find the best source for affine information, but not dipy 1.1.1 .

Until a new version of dipy is released, we can use this PR with some datasets. This PR will probably not need to be merged, especially if a new version of dipy is releasing soon. 