### PR TITLE
Require dipy versions higher than 0.12, so that we can use current ma…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.6
 install_requires =
     scikit_image==0.16.2
     nibabel==3.0.2
-    dipy==1.2.0
+    dipy>=1.2.0
     scipy>=1.2.0
     numpy==1.17.5
     pandas==1.0.3


### PR DESCRIPTION
…ster.