### PR TITLE
ENH Disabling progress bars for sphinx-gallery

### DIFF
--- a/docs/source/_progressbars.py
+++ b/docs/source/_progressbars.py
@@ -1,0 +1,37 @@
+def _no_tqdm(iterable, *args, **kwargs):
+    """
+    replacement for tqdm that just passes back the iterable to silence `tqdm`
+    """
+    return iterable
+
+
+def _no_progressbar(progress, total_length):
+    """
+    no-op calls to update the `fetcher` progress bar
+    """
+    return
+
+
+def reset_progressbars(gallery_conf, fname):
+    """
+    monkey patch to disable various progress bar output for examples. the
+    progress bar updates pollutes sphinx gallery output. using this monkey
+    patch from the spinx-build will leave the progress bars in place for other
+    uses.
+    """
+
+    # disable tqdm
+    import AFQ.data as afd
+    import AFQ._fixes as fixes
+    import AFQ.segmentation as seg
+    import AFQ.viz.utils as utils
+
+    afd.tqdm = _no_tqdm
+    fixes.tqdm = _no_tqdm
+    seg.tqdm = _no_tqdm
+    utils.tqdm = _no_tqdm
+
+    # disable update_progressbar
+    from dipy.data import fetcher
+
+    fetcher.update_progressbar = _no_progressbar

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import sys, os
+
+sys.path.insert(0, os.path.abspath('.'))
 sys.path.append(os.path.abspath('sphinxext'))
-# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -181,6 +182,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 from plotly.io._sg_scraper import plotly_sg_scraper
 image_scrapers = ('matplotlib', plotly_sg_scraper,)
 
+from _progressbars import reset_progressbars
 
 sphinx_gallery_conf = {
      # path to your examples scripts
@@ -188,6 +190,7 @@ sphinx_gallery_conf = {
      # path where to save gallery generated examples
      'gallery_dirs': 'auto_examples',
      'image_scrapers': image_scrapers,
+     'reset_modules': (reset_progressbars),
 }
 
 # Auto API


### PR DESCRIPTION
This enhancement follows from [suggestion by @arokem](https://github.com/yeatmanlab/pyAFQ/pull/476/files#r498533426) in #476 and uses the sphinx-gallery [resetting behavior for custom libraries](https://sphinx-gallery.github.io/stable/advanced.html#define-resetting-behavior-e-g-for-custom-libraries). 

It is also worth noting as currently implemented will run for all sphinx-gallery examples.