### PR TITLE
Read and resample ROI data.

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -151,7 +151,7 @@ def read_callosum_templates(resample_to=False):
     return template_dict
 
 
-def read_roi(roi, resample_to=None):
+def read_resample_roi(roi, resample_to=None):
     """
     Reads an roi from file-name/img and resamples it to conform with
     another file-name/img.

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -151,7 +151,7 @@ def read_callosum_templates(resample_to=False):
     return template_dict
 
 
-def read_resample_roi(roi, resample_to=None):
+def read_resample_roi(roi, resample_to=None, threshold=False):
     """
     Reads an roi from file-name/img and resamples it to conform with
     another file-name/img.
@@ -166,6 +166,12 @@ def read_resample_roi(roi, resample_to=None):
         A template image to resample to. Typically, this should be the
         template to which individual-level data are registered. Defaults to
         the MNI template.
+
+    threshold: bool or float
+        If set to False (default), resampled result is returned. Otherwise,
+        the resampled result is thresholded at this value and binarized.
+        This is not applied if the input ROI is already in the space of the
+        output.
 
     Returns
     -------
@@ -184,13 +190,16 @@ def read_resample_roi(roi, resample_to=None):
     if np.allclose(resample_to.affine, roi.affine):
         return roi
 
-    img = nib.Nifti1Image(
-        reg.resample(roi.get_fdata(),
-                     resample_to,
-                     roi.affine,
-                     resample_to.affine),
-        resample_to.affine)
+    as_array = reg.resample(roi.get_fdata(),
+                            resample_to,
+                            roi.affine,
+                            resample_to.affine)
+    if threshold:
+        as_array = (as_array > threshold).astype(int)
 
+    img = nib.Nifti1Image(
+        as_array,
+        resample_to.affine)
 
     return img
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -180,12 +180,17 @@ def read_roi(roi, resample_to=None):
 
     if isinstance(resample_to, str):
         resample_to = nib.load(resample_to)
+
+    if np.allclose(resample_to.affine, roi.affine):
+        return roi
+
     img = nib.Nifti1Image(
         reg.resample(roi.get_fdata(),
                      resample_to,
                      roi.affine,
                      resample_to.affine),
         resample_to.affine)
+
 
     return img
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -151,6 +151,45 @@ def read_callosum_templates(resample_to=False):
     return template_dict
 
 
+def read_roi(roi, resample_to=None):
+    """
+    Reads an roi from file-name/img and resamples it to conform with
+    another file-name/img.
+
+    Parameters
+    ----------
+    roi : str or nibabel image class instance.
+        Should contain a binary volume with 1s in the region of interest and
+        0s elsewhere.
+
+    resample_to : str or nibabel image class instance, optional
+        A template image to resample to. Typically, this should be the
+        template to which individual-level data are registered. Defaults to
+        the MNI template.
+
+    Returns
+    -------
+    nibabel image class instance that contains the binary ROI resampled into
+    the requested space.
+    """
+    if isinstance(roi, str):
+        roi = nib.load(roi)
+
+    if resample_to is None:
+        resample_to = read_mni_template()
+
+    if isinstance(resample_to, str):
+        resample_to = nib.load(resample_to)
+    img = nib.Nifti1Image(
+        reg.resample(roi.get_fdata(),
+                     resample_to,
+                     roi.affine,
+                     resample_to.affine),
+        resample_to.affine)
+
+    return img
+
+
 template_fnames = ["ATR_roi1_L.nii.gz",
                    "ATR_roi1_R.nii.gz",
                    "ATR_roi2_L.nii.gz",

--- a/AFQ/tests/test_data.py
+++ b/AFQ/tests/test_data.py
@@ -212,11 +212,12 @@ def test_bundles_to_aal():
         ],
     )
 
+
 def test_read_roi():
     aff1 = np.eye(4)
     template = nib.Nifti1Image(np.ones((10, 10, 10)), aff1)
     aff2 = aff1[:]
-    aff2[0,0] = -1
+    aff2[0, 0] = -1
     roi = nib.Nifti1Image(np.zeros((10, 10, 10)), aff2)
     img = afd.read_roi(roi, resample_to=template)
     npt.assert_equal(img.affine, template.affine)

--- a/AFQ/tests/test_data.py
+++ b/AFQ/tests/test_data.py
@@ -13,6 +13,7 @@ from moto import mock_s3
 from uuid import uuid4
 
 import AFQ.data as afd
+import nibabel as nib
 
 DATA_PATH = op.join(op.abspath(op.dirname(__file__)), "data")
 TEST_BUCKET = "test-bucket"
@@ -211,3 +212,11 @@ def test_bundles_to_aal():
         ],
     )
 
+def test_read_roi():
+    aff1 = np.eye(4)
+    template = nib.Nifti1Image(np.ones((10, 10, 10)), aff1)
+    aff2 = aff1[:]
+    aff2[0,0] = -1
+    roi = nib.Nifti1Image(np.zeros((10, 10, 10)), aff2)
+    img = afd.read_roi(roi, resample_to=template)
+    npt.assert_equal(img.affine, template.affine)

--- a/AFQ/tests/test_data.py
+++ b/AFQ/tests/test_data.py
@@ -219,5 +219,5 @@ def test_read_roi():
     aff2 = aff1[:]
     aff2[0, 0] = -1
     roi = nib.Nifti1Image(np.zeros((10, 10, 10)), aff2)
-    img = afd.read_roi(roi, resample_to=template)
+    img = afd.read_resample_roi(roi, resample_to=template)
     npt.assert_equal(img.affine, template.affine)


### PR DESCRIPTION
This is a utility function for handling user-provided ROIs that are registered to MNI space, but are stored with an affine that differs from MNI.
