### PR TITLE
FIX: combine AFQ profiles

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -2019,6 +2019,11 @@ def combine_list_of_profiles(profile_fnames, out_file):
         dfs.append(profiles)
 
     df = pd.concat(dfs)
-    os.makedirs(op.dirname(out_file), exist_ok=True)
+    out_dir = op.dirname(out_file)
+    if out_dir:
+        # If user supplied only a filename with no dirname, then op.dirname
+        # will return an empty string and we assume the user wants the file in
+        # the current directory. Therefore, no mkdir is necessary.
+        os.makedirs(out_dir, exist_ok=True)
     df.to_csv(out_file, index=False)
     return df

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1986,12 +1986,13 @@ def download_and_combine_afq_profiles(out_file, bucket, study_s3_prefix,
     if upload is not None:
         upload.put(
             out_file,
-            os.join(
+            "/".join([
                 bucket,
                 study_s3_prefix,
-                "derivatives/afq",
+                "derivatives",
+                "afq",
                 "combined_tract_profiles.csv"
-            ))
+            ]))
     return df
 
 

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -17,6 +17,8 @@ from dipy.io.gradients import read_bvals_bvecs
 from dipy.stats.analysis import afq_profile, gaussian_weights
 
 from bids.layout import BIDSLayout
+import bids.config as bids_config
+bids_config.set_option('extension_initial_dot', True)
 
 from .version import version as pyafq_version
 import AFQ.data as afd

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1966,9 +1966,9 @@ def download_and_combine_afq_profiles(out_file, bucket, study_s3_prefix,
             t_dir,
             include_modality_agnostic=False,
             include_derivs="afq",
-            include_derivs_dataset_description=False,
+            include_derivs_dataset_description=True,
             suffix="profiles.csv")
-        temp_study = BIDSLayout(t_dir, validate=False)
+        temp_study = BIDSLayout(t_dir, validate=False, derivatives=True)
         if session is None:
             profiles = temp_study.get(
                 extension='csv',

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1951,7 +1951,7 @@ def download_and_combine_afq_profiles(bucket, study_s3_prefix, out_file=None,
     out_file : filename, optional
         Filename for the combined output CSV.
     upload : bool or str, optional
-        If True, upload the combined CSV to Amazon S3 at 
+        If True, upload the combined CSV to Amazon S3 at
         bucket/study_s3_prefix/derivatives/afq. If a string,
         assume string is an Amazon S3 URI and upload there.
         Defaut: False

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -15,6 +15,9 @@ import logging
 import time
 
 from bids import BIDSLayout
+import bids.config as bids_config
+bids_config.set_option('extension_initial_dot', True)
+
 from botocore import UNSIGNED
 from botocore.client import Config
 from dask import compute, delayed
@@ -539,6 +542,8 @@ class S3BIDSSubject:
         study : AFQ.data.S3BIDSStudy
             The S3BIDSStudy for which this subject was a participant
         """
+        logging.getLogger("botocore").setLevel(logging.WARNING)
+
         if not isinstance(subject_id, str):
             raise TypeError('subject_id must be a string.')
 
@@ -903,6 +908,8 @@ class S3BIDSStudy:
             class that quacks like AFQ.data.S3BIDSSubject. Default:
             S3BIDSSubject
         """
+        logging.getLogger("botocore").setLevel(logging.WARNING)
+
         if not isinstance(study_id, str):
             raise TypeError('`study_id` must be a string.')
 


### PR DESCRIPTION
Resolves #584 
Resolves #375 

This PR fixes a couple issues in `download_and_combine_afq_profiles`. First, since the derivatives weren't included in the `BIDSLayout`, the `layout.get()` call returned no files and there were none available to concatenate. Next, unless `out_file` was an absolute path, `out_file` in the `InTemporaryDirectory()` context did not point to the same file as the one outside of it in the `fs.put()` command. And indeed, the csv would not be saved locally in the user's current working directory, but instead in the temp directory. This PR fixes those issues and in so doing, it makes the `combine_list_of_profiles` function only return the dataframe. Saving to file is now done outside that function.