### PR TITLE
FIX: Traverse BIDS hierarchy to find masks, bvals, and bvecs

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -542,8 +542,10 @@ class AFQ(object):
                 # specify acquisition labels, but pop suffix since it is
                 # already specified inside ``get_bvec()`` and ``get_bval()``
                 suffix = bids_filters.pop("suffix", None)
-                bvec_file_list.append(bids_layout.get_bvec(dwi_data_file, **bids_filters))
-                bval_file_list.append(bids_layout.get_bval(dwi_data_file, **bids_filters))
+                bvec_file_list.append(bids_layout.get_bvec(dwi_data_file,
+                                                           **bids_filters))
+                bval_file_list.append(bids_layout.get_bval(dwi_data_file,
+                                                           **bids_filters))
                 if suffix is not None:
                     bids_filters["suffix"] = suffix
 

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -522,7 +522,7 @@ class AFQ(object):
                     "suffix": "dwi",
                 }
                 dwi_bids_filters.update(bids_filters)
-                dwi_files = bids_layout.get(dwi_bids_filters)
+                dwi_files = bids_layout.get(**dwi_bids_filters)
 
                 if (not len(dwi_files)):
                     self.logger.warning(

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -517,7 +517,7 @@ class AFQ(object):
                     "session": session,
                     "return_type": "filename",
                     "scope": dmriprep,
-                    "data_type": "dwi",
+                    "datatype": "dwi",
                     "extension": "nii.gz",
                     "suffix": "dwi",
                 }

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1706,8 +1706,8 @@ def organize_cfin_data(path=None):
         nib.save(t1_img, op.join(anat_folder, 'sub-01_ses-01_T1w.nii.gz'))
         dwi_img, gtab = dpd.read_cfin_dwi()
         nib.save(dwi_img, op.join(dwi_folder, 'sub-01_ses-01_dwi.nii.gz'))
-        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvecs'), gtab.bvecs)
-        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvals'), gtab.bvals)
+        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvec'), gtab.bvecs)
+        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bval'), gtab.bvals)
 
     to_bids_description(
         bids_path,
@@ -1743,8 +1743,8 @@ def organize_stanford_data(path=None):
             └── sub-01
                 └── ses-01
                     └── dwi
-                        ├── sub-01_ses-01_dwi.bvals
-                        ├── sub-01_ses-01_dwi.bvecs
+                        ├── sub-01_ses-01_dwi.bval
+                        ├── sub-01_ses-01_dwi.bvec
                         └── sub-01_ses-01_dwi.nii.gz
 
     """
@@ -1785,8 +1785,8 @@ def organize_stanford_data(path=None):
 
         dwi_img, gtab = dpd.read_stanford_hardi()
         nib.save(dwi_img, op.join(dwi_folder, 'sub-01_ses-01_dwi.nii.gz'))
-        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvecs'), gtab.bvecs)
-        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvals'), gtab.bvals)
+        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bvec'), gtab.bvecs)
+        np.savetxt(op.join(dwi_folder, 'sub-01_ses-01_dwi.bval'), gtab.bvals)
     else:
         logger.info('Dataset is already in place. If you want to fetch it '
                     + 'again please first remove the folder '

--- a/AFQ/mask.py
+++ b/AFQ/mask.py
@@ -162,7 +162,7 @@ class MaskFile(StrInstantiatesMixin):
     def find_path(self, bids_layout, from_path, subject, session):
         if session not in self.fnames:
             self.fnames[session] = {}
-        
+
         nearest_mask = bids_layout.get_nearest(
             from_path,
             **self.filters,
@@ -175,8 +175,12 @@ class MaskFile(StrInstantiatesMixin):
         )
 
         self.fnames[session][subject] = nearest_mask
-        from_path_subject = bids_layout.parse_file_entities(from_path).get("subject", None)
-        mask_subject = bids_layout.parse_file_entities(nearest_mask).get("subject", None)
+        from_path_subject = bids_layout.parse_file_entities(from_path).get(
+            "subject", None
+        )
+        mask_subject = bids_layout.parse_file_entities(nearest_mask).get(
+            "subject", None
+        )
         if from_path_subject != mask_subject:
             raise ValueError(
                 f"Expected subject IDs to match for the retrieved mask file "

--- a/AFQ/mask.py
+++ b/AFQ/mask.py
@@ -163,15 +163,29 @@ class MaskFile(StrInstantiatesMixin):
         if session not in self.fnames:
             self.fnames[session] = {}
 
+        # First, try to match the session.
         nearest_mask = bids_layout.get_nearest(
             from_path,
             **self.filters,
             extension=".nii.gz",
             suffix=self.suffix,
+            session=session,
             subject=subject,
             full_search=True,
             strict=False,
         )
+
+        if nearest_mask is None:
+            # If that fails, loosen session restriction
+            nearest_mask = bids_layout.get_nearest(
+                from_path,
+                **self.filters,
+                extension=".nii.gz",
+                suffix=self.suffix,
+                subject=subject,
+                full_search=True,
+                strict=False,
+            )
 
         self.fnames[session][subject] = nearest_mask
         from_path_subject = bids_layout.parse_file_entities(from_path).get(

--- a/AFQ/mask.py
+++ b/AFQ/mask.py
@@ -168,7 +168,6 @@ class MaskFile(StrInstantiatesMixin):
             **self.filters,
             extension=".nii.gz",
             suffix=self.suffix,
-            session=session,
             subject=subject,
             full_search=True,
             strict=False,

--- a/AFQ/mask.py
+++ b/AFQ/mask.py
@@ -159,15 +159,31 @@ class MaskFile(StrInstantiatesMixin):
         self.filters = filters
         self.fnames = {}
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         if session not in self.fnames:
             self.fnames[session] = {}
-        self.fnames[session][subject] = bids_layout.get(
-            subject=subject, session=session,
-            extension='.nii.gz',
-            return_type='filename',
+        
+        nearest_mask = bids_layout.get_nearest(
+            from_path,
+            **self.filters,
+            extension=".nii.gz",
             suffix=self.suffix,
-            **self.filters)[0]
+            session=session,
+            subject=subject,
+            full_search=True,
+            strict=False,
+        )
+
+        self.fnames[session][subject] = nearest_mask
+        from_path_subject = bids_layout.parse_file_entities(from_path).get("subject", None)
+        mask_subject = bids_layout.parse_file_entities(nearest_mask).get("subject", None)
+        if from_path_subject != mask_subject:
+            raise ValueError(
+                f"Expected subject IDs to match for the retrieved mask file "
+                f"and the supplied `from_path` file. Got sub-{mask_subject} "
+                f"from mask file {nearest_mask} and sub-{from_path_subject} "
+                f"from `from_path` file {from_path}."
+            )
 
     def get_path_data_affine(self, afq_object, row):
         mask_file = self.fnames[row['ses']][row['subject']]
@@ -209,7 +225,7 @@ class FullMask(StrInstantiatesMixin):
     def __init__(self):
         pass
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         pass
 
     def get_mask(self, afq_object, row):
@@ -234,7 +250,7 @@ class RoiMask(StrInstantiatesMixin):
     def __init__(self):
         pass
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         pass
 
     def get_mask(self, afq_object, row):
@@ -286,7 +302,7 @@ class B0Mask(StrInstantiatesMixin):
     def __init__(self, median_otsu_kwargs={}):
         self.median_otsu_kwargs = median_otsu_kwargs
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         pass
 
     def get_mask(self, afq_object, row):
@@ -448,7 +464,7 @@ class ScalarMask(MaskFile):
         self.scalar = scalar
 
     # overrides MaskFile
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         pass
 
     # overrides MaskFile
@@ -536,9 +552,9 @@ class PFTMask(StrInstantiatesMixin):
         """
         self.probsegs = (WM_probseg, GM_probseg, CSF_probseg)
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         for probseg in self.probsegs:
-            probseg.find_path(bids_layout, subject, session)
+            probseg.find_path(bids_layout, from_path, subject, session)
 
     def get_mask(self, afq_object, row):
         probseg_imgs = []
@@ -547,7 +563,7 @@ class PFTMask(StrInstantiatesMixin):
             data, affine, meta = probseg.get_mask(afq_object, row)
             probseg_imgs.append(nib.Nifti1Image(data, affine))
             probseg_metas.append(meta)
-        return probseg_imgs, _, dict(sources=probseg_metas)
+        return probseg_imgs, None, dict(sources=probseg_metas)
 
 
 class CombinedMask(StrInstantiatesMixin, CombineMaskMixin):
@@ -581,9 +597,9 @@ class CombinedMask(StrInstantiatesMixin, CombineMaskMixin):
         CombineMaskMixin.__init__(self, combine)
         self.mask_list = mask_list
 
-    def find_path(self, bids_layout, subject, session):
+    def find_path(self, bids_layout, from_path, subject, session):
         for mask in self.mask_list:
-            mask.find_path(bids_layout, subject, session)
+            mask.find_path(bids_layout, from_path, subject, session)
 
     def get_mask(self, afq_object, row):
         self.mask_draft = None

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -71,11 +71,11 @@ def create_dummy_data(dmriprep_dir, subject, session=None):
 
     np.savetxt(
         op.join(
-            dmriprep_dir, data_dir, 'dwi', 'dwi.bvals'),
+            dmriprep_dir, data_dir, 'dwi', 'dwi.bval'),
         bvals)
     np.savetxt(
         op.join(
-            dmriprep_dir, data_dir, 'dwi', 'dwi.bvecs'),
+            dmriprep_dir, data_dir, 'dwi', 'dwi.bvec'),
         bvecs)
     nib.save(
         nib.Nifti1Image(data, aff),

--- a/AFQ/tests/test_mask.py
+++ b/AFQ/tests/test_mask.py
@@ -1,5 +1,7 @@
+import os.path as op
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from bids.layout import BIDSLayout
 
@@ -75,13 +77,28 @@ def test_resample_mask():
         mask_data.dtype)
 
 
-def test_find_path():
+@pytest.mark.parametrize("subject", ["01", "02"])
+@pytest.mark.parametrize("session", ["01", "02"])
+def test_find_path(subject, session):
     bids_dir = create_dummy_bids_path(2, 2)
-    print(bids_dir)
     bids_layout = BIDSLayout(bids_dir, derivatives=True)
 
+    test_dwi_path = bids_layout.get(
+        subject=subject, session=session, return_type="filename", suffix="dwi", extension="nii.gz"
+    )[0]
+
     mask_file = MaskFile("seg", {'scope': 'synthetic'})
-    mask_file.find_path(bids_layout, '01', '01')
-    mask_file.find_path(bids_layout, '02', '01')
-    mask_file.find_path(bids_layout, '01', '02')
-    mask_file.find_path(bids_layout, '02', '02')
+    mask_file.find_path(bids_layout, test_dwi_path, subject, session)
+
+    assert mask_file.fnames[session][subject] == op.join(
+        bids_dir, "derivatives", "dmriprep", "sub-" + subject, "ses-" + session, "anat", "seg.nii.gz"
+    )
+
+    other_sub = "01" if subject=="02" else "02",
+    with pytest.raises(ValueError):
+        mask_file.find_path(
+            bids_layout,
+            test_dwi_path,
+            subject=other_sub,
+            session=session,
+        )

--- a/AFQ/tests/test_mask.py
+++ b/AFQ/tests/test_mask.py
@@ -84,17 +84,19 @@ def test_find_path(subject, session):
     bids_layout = BIDSLayout(bids_dir, derivatives=True)
 
     test_dwi_path = bids_layout.get(
-        subject=subject, session=session, return_type="filename", suffix="dwi", extension="nii.gz"
+        subject=subject, session=session, return_type="filename",
+        suffix="dwi", extension="nii.gz"
     )[0]
 
     mask_file = MaskFile("seg", {'scope': 'synthetic'})
     mask_file.find_path(bids_layout, test_dwi_path, subject, session)
 
     assert mask_file.fnames[session][subject] == op.join(
-        bids_dir, "derivatives", "dmriprep", "sub-" + subject, "ses-" + session, "anat", "seg.nii.gz"
+        bids_dir, "derivatives", "dmriprep", "sub-" + subject,
+        "ses-" + session, "anat", "seg.nii.gz"
     )
 
-    other_sub = "01" if subject=="02" else "02",
+    other_sub = "01" if subject == "02" else "02"
     with pytest.raises(ValueError):
         mask_file.find_path(
             bids_layout,

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import numpy as np
 import nibabel as nib
 import dipy.reconst.shm as shm
@@ -166,7 +167,7 @@ def track(params_file, directions="det", max_angle=30., sphere=None,
                 "You are using PFT tracking, but did not provide a string ",
                 "'stop_threshold' input. ",
                 "Possible inputs are: 'CMC' or 'ACT'")
-        if not isinstance(stop_mask, tuple):
+        if not isinstance(stop_mask, Iterable) and len(stop_mask) == 3:
             raise RuntimeError(
                 "You are using PFT tracking, but did not provide a tuple for",
                 "`stop_mask`",

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -167,11 +167,11 @@ def track(params_file, directions="det", max_angle=30., sphere=None,
                 "You are using PFT tracking, but did not provide a string ",
                 "'stop_threshold' input. ",
                 "Possible inputs are: 'CMC' or 'ACT'")
-        if not isinstance(stop_mask, Iterable) and len(stop_mask) == 3:
+        if not (isinstance(stop_mask, Iterable) and len(stop_mask) == 3):
             raise RuntimeError(
-                "You are using PFT tracking, but did not provide a tuple for",
-                "`stop_mask`",
-                "input. Expected a (pve_wm, pve_gm, pve_csf) tuple.")
+                "You are using PFT tracking, but did not provide a length "
+                "3 iterable for `stop_mask`. "
+                "Expected a (pve_wm, pve_gm, pve_csf) tuple.")
         pves = []
         pve_imgs = []
         vox_sizes = []

--- a/docs/source/usage/data.rst
+++ b/docs/source/usage/data.rst
@@ -41,6 +41,6 @@ data set in a directory called `stanford_hardi`::
     └── sub-01
         └── ses-01
             └── dwi
-                ├── sub-01_ses-01_dwi.bvals
-                ├── sub-01_ses-01_dwi.bvecs
+                ├── sub-01_ses-01_dwi.bval
+                ├── sub-01_ses-01_dwi.bvec
                 └── sub-01_ses-01_dwi.nii.gz


### PR DESCRIPTION
This PR traverses the BIDS hierarchy to find masks, bval files, and bvec files instead of assuming that they will be found in the same session. It is part bugfix, part enhancement because it also fixes the underscore error in `PFTMask.get_mask()`.

Traversing the hierarchy should allow it to interact with common output patterns from nipreps.