### PR TITLE
[ENH] Allow the user to specify what range the color by volume should shade over

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1490,7 +1490,7 @@ class AFQ(object):
                      volume=None,
                      xform_volume=False,
                      color_by_volume=None,
-                     cbv_lims=(None, None),
+                     cbv_lims=[None, None],
                      xform_color_by_volume=False,
                      n_points=40):
         bundles_file = self._clean_bundles(row)
@@ -1546,7 +1546,7 @@ class AFQ(object):
                   volume=None,
                   xform_volume=False,
                   color_by_volume=None,
-                  cbv_lims=(None, None),
+                  cbv_lims=[None, None],
                   xform_color_by_volume=False,
                   n_points=40):
         bundles_file = self._clean_bundles(row)
@@ -1920,7 +1920,7 @@ class AFQ(object):
                     volume=None,
                     xform_volume=False,
                     color_by_volume=None,
-                    cbv_lims=(None, None),
+                    cbv_lims=[None, None],
                     xform_color_by_volume=False,
                     n_points=40,
                     inline=False,
@@ -1943,7 +1943,7 @@ class AFQ(object):
                  volume=None,
                  xform_volume=False,
                  color_by_volume=None,
-                 cbv_lims=(None, None),
+                 cbv_lims=[None, None],
                  xform_color_by_volume=False,
                  n_points=40,
                  inline=False,

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1490,6 +1490,7 @@ class AFQ(object):
                      volume=None,
                      xform_volume=False,
                      color_by_volume=None,
+                     cbv_lims=(None, None),
                      xform_color_by_volume=False,
                      n_points=40):
         bundles_file = self._clean_bundles(row)
@@ -1509,6 +1510,7 @@ class AFQ(object):
 
         figure = self.viz.visualize_bundles(bundles_file,
                                             color_by_volume=color_by_volume,
+                                            cbv_lims=cbv_lims,
                                             bundle_dict=self.bundle_dict,
                                             n_points=n_points,
                                             interact=interactive,
@@ -1544,6 +1546,7 @@ class AFQ(object):
                   volume=None,
                   xform_volume=False,
                   color_by_volume=None,
+                  cbv_lims=(None, None),
                   xform_color_by_volume=False,
                   n_points=40):
         bundles_file = self._clean_bundles(row)
@@ -1570,6 +1573,7 @@ class AFQ(object):
                 figure = self.viz.visualize_bundles(
                     bundles_file,
                     color_by_volume=color_by_volume,
+                    cbv_lims=cbv_lims,
                     bundle_dict=self.bundle_dict,
                     bundle=uid,
                     n_points=n_points,
@@ -1916,6 +1920,7 @@ class AFQ(object):
                     volume=None,
                     xform_volume=False,
                     color_by_volume=None,
+                    cbv_lims=(None, None),
                     xform_color_by_volume=False,
                     n_points=40,
                     inline=False,
@@ -1926,6 +1931,7 @@ class AFQ(object):
             volume=volume,
             xform_volume=xform_volume,
             color_by_volume=color_by_volume,
+            cbv_lims=cbv_lims,
             xform_color_by_volume=xform_color_by_volume,
             n_points=n_points,
             inline=inline,
@@ -1937,6 +1943,7 @@ class AFQ(object):
                  volume=None,
                  xform_volume=False,
                  color_by_volume=None,
+                 cbv_lims=(None, None),
                  xform_color_by_volume=False,
                  n_points=40,
                  inline=False,
@@ -1951,6 +1958,7 @@ class AFQ(object):
             volume=volume,
             xform_volume=xform_volume,
             color_by_volume=color_by_volume,
+            cbv_lims=cbv_lims,
             xform_color_by_volume=xform_color_by_volume,
             n_points=n_points)
 

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -37,8 +37,8 @@ def _inline_interact(scene, inline, interact):
 
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
                       bundle=None, colors=None, color_by_volume=None,
-                      figure=None, background=(1, 1, 1), interact=False,
-                      inline=False):
+                      cbv_lims=(None, None), figure=None, background=(1, 1, 1),
+                      interact=False, inline=False):
     """
     Visualize bundles in 3D using VTK
 
@@ -74,6 +74,19 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
         If this is a list, each item is an RGB tuple. Defaults to a list
         with Tableau 20 RGB values if bundle_dict is None, or dict from
         bundles to Tableau 20 RGB values if bundle_dict is not None.
+
+    color_by_volume : ndarray or str, optional
+        3d volume use to shade the bundles. If None, no shading
+        is performed. Only works when using the plotly backend.
+        Default: None
+
+    cbv_lims : tuple
+        Of the form (lower bound, upper bound). Shading based on
+        color_by_volume will only differentiate values within these bounds.
+        If lower bound is None, will default to 0.
+        If upper bound is None, will default to the maximum value in
+        color_by_volume.
+        Default: (None, None)
 
     background : tuple, optional
         RGB values for the background. Default: (1, 1, 1), which is white

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -37,7 +37,7 @@ def _inline_interact(scene, inline, interact):
 
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
                       bundle=None, colors=None, color_by_volume=None,
-                      cbv_lims=(None, None), figure=None, background=(1, 1, 1),
+                      cbv_lims=[None, None], figure=None, background=(1, 1, 1),
                       interact=False, inline=False):
     """
     Visualize bundles in 3D using VTK
@@ -80,13 +80,13 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
         is performed. Only works when using the plotly backend.
         Default: None
 
-    cbv_lims : tuple
+    cbv_lims : ndarray
         Of the form (lower bound, upper bound). Shading based on
         color_by_volume will only differentiate values within these bounds.
         If lower bound is None, will default to 0.
         If upper bound is None, will default to the maximum value in
         color_by_volume.
-        Default: (None, None)
+        Default: [None, None]
 
     background : tuple, optional
         RGB values for the background. Default: (1, 1, 1), which is white

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -72,7 +72,7 @@ def set_layout(figure, color=None):
 
 
 def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None,
-                      cbv_lims=(None, None)):
+                      cbv_lims=[None, None]):
     color = np.asarray(color)
 
     plotting_shape = (sls._data.shape[0] + sls._offsets.shape[0])
@@ -89,8 +89,8 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None,
     if cbv is not None:
         customdata = np.zeros(plotting_shape)
         line_color = np.zeros((plotting_shape, 3))
-        color_constant = (color / color.max()) * (1.4 /
-            (cbv_lims[1] - cbv_lims[0])) + cbv_lims[0]
+        color_constant = (color / color.max())\
+            * (1.4 / (cbv_lims[1] - cbv_lims[0])) + cbv_lims[0]
     else:
         customdata = np.zeros(plotting_shape)
         line_color = np.zeros((plotting_shape, 3))
@@ -150,7 +150,7 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None,
 
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
                       bundle=None, colors=None, color_by_volume=None,
-                      cbv_lims=(None, None), figure=None,
+                      cbv_lims=[None, None], figure=None,
                       background=(1, 1, 1), interact=False,
                       inline=False):
     """
@@ -194,13 +194,13 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
         is performed. Only works when using the plotly backend.
         Default: None
 
-    cbv_lims : tuple
+    cbv_lims : ndarray
         Of the form (lower bound, upper bound). Shading based on
         color_by_volume will only differentiate values within these bounds.
         If lower bound is None, will default to 0.
         If upper bound is None, will default to the maximum value in
         color_by_volume.
-        Default: (None, None)
+        Default: [None, None]
 
     background : tuple, optional
         RGB values for the background. Default: (1, 1, 1), which is white


### PR DESCRIPTION
This is useful in baby brains for example, where one large FA value somewhere in the brain throws off our default scale of 0 to the maximum value.
Closes #547 .