### PR TITLE
[ENH] Avoid hard crash when bundle not in AAL atlas

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -2078,9 +2078,13 @@ def bundles_to_aal(bundles, atlas=None):
         "ARC_R": [['rightfrontal'], ['rightarctemp']]}
 
     targets = []
+    logger = logging.getLogger('AFQ.data')
     for bundle in bundles:
         targets.append([])
         if bundle not in endpoint_dict.keys():
+            logger.warning((
+                f"Endpoints not found for bundle {bundle}. "
+                f"Endpoint filtering will not be performed for this bundle."))
             targets[-1].append(None)
             targets[-1].append(None)
         else:

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1,3 +1,10 @@
+import AFQ.registration as reg
+from dipy.segment.clustering import QuickBundles
+from dipy.segment.metric import (AveragePointwiseEuclideanMetric,
+                                 ResampleFeature)
+from dipy.io.streamline import load_tractogram, load_trk
+from dipy.data.fetcher import _make_fetcher
+import dipy.data as dpd
 from io import BytesIO
 import gzip
 import os
@@ -43,23 +50,12 @@ finally:
     logging.captureWarnings(False)
     warnings.formatwarning = default_warning_format
 
-import dipy.data as dpd
-from dipy.data.fetcher import _make_fetcher
-from dipy.io.streamline import load_tractogram, load_trk
-from dipy.segment.metric import (AveragePointwiseEuclideanMetric,
-                                 ResampleFeature)
-
-
-from dipy.segment.clustering import QuickBundles
-
-import AFQ.registration as reg
 
 __all__ = ["fetch_callosum_templates", "read_callosum_templates",
            "fetch_templates", "read_templates", "fetch_hcp",
            "fetch_stanford_hardi_tractography",
            "read_stanford_hardi_tractography",
            "organize_stanford_data"]
-
 
 
 BUNDLE_RECO_2_AFQ = \
@@ -1883,7 +1879,6 @@ def read_hcp_atlas(n_bundles=16):
     return bundle_dict
 
 
-
 fetch_aal_atlas = _make_fetcher(
     "fetch_aal_atlas",
     op.join(afq_home,
@@ -2085,11 +2080,15 @@ def bundles_to_aal(bundles, atlas=None):
     targets = []
     for bundle in bundles:
         targets.append([])
-        for region in endpoint_dict[bundle]:
-            if region is None:
-                targets[-1].append(None)
-            else:
-                targets[-1].append(aal_to_regions(region, atlas=atlas))
+        if bundle not in endpoint_dict.keys():
+            targets[-1].append(None)
+            targets[-1].append(None)
+        else:
+            for region in endpoint_dict[bundle]:
+                if region is None:
+                    targets[-1].append(None)
+                else:
+                    targets[-1].append(aal_to_regions(region, atlas=atlas))
 
     return targets
 


### PR DESCRIPTION
If the user adds a new bundle and runs pyAFQ naively without changing the AAL atlas, pyAFQ will currently hard crash. I think the better solution is to just not endpoint filter that bundle. 

Custom endpoint filtering is being handled already in #589