### PR TITLE
[WIP] [ENH] allow user to specify callosal bundles in list of bundle names for bundle_info, add example

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -53,6 +53,10 @@ def do_preprocessing():
 BUNDLES = ["ATR", "CGC", "CST", "IFO", "ILF", "SLF", "ARC", "UNC",
            "FA", "FP"]
 
+CALLOSAL_BUNDLES = [
+    'AntFrontal', 'Motor', 'Occipital', 'Orbital', 'PostParietal',
+    'SupFrontal', 'SupParietal', 'Temporal']
+
 # See: https://www.cmu.edu/dietrich/psychology/cognitiveaxon/documents/yeh_etal_2018.pdf  # noqa
 
 RECO_BUNDLES_16 = [
@@ -131,6 +135,16 @@ def make_bundle_dict(bundle_names=BUNDLES, seg_algo="afq", resample_to=False):
                         'rules': [True, True, False],
                         'prob_map': templates[name + hemi + '_prob_map'],
                         'cross_midline': False,
+                        'uid': uid}
+                    uid += 1
+            elif name in CALLOSAL_BUNDLES:
+                for hemi in ['_R', '_L']:
+                    afq_bundles["AntFrontal" + hemi] = {
+                        'ROIs': [callosal_templates["L_" + name],
+                                callosal_templates["R_" + name],
+                                callosal_templates["Callosum_midsag"]],
+                        'rules': [True, True, True],
+                        'cross_midline': True,
                         'uid': uid}
                     uid += 1
             else:

--- a/examples/plot_afq_callosal.py
+++ b/examples/plot_afq_callosal.py
@@ -1,0 +1,46 @@
+"""
+==========================
+Calossal bundles using AFQ API
+==========================
+
+An example using the AFQ API to find calossal bundles with the
+# TODO : find source of calossal bundles
+
+"""
+import os.path as op
+
+import plotly
+
+from AFQ import api
+import AFQ.data as afd
+
+##########################################################################
+# Get some example data
+# ---------------------
+#
+# Retrieves `Stanford HARDI dataset <https://purl.stanford.edu/ng782rw8378>`_.
+#
+
+afd.organize_stanford_data()
+
+##########################################################################
+# Initialize an AFQ object:
+# -------------------------
+#
+# We specify bundle_info as the default bundles list (api.BUNDLES) plus the
+# callosal bundle list. This tells the AFQ object to use bundles from both
+# the standard and callosal templates.
+
+myafq = api.AFQ(bids_path=op.join(afd.afq_home,
+                                  'stanford_hardi'),
+                dmriprep='vistasoft',
+                bundle_info=api.BUNDLES + api.CALLOSAL_BUNDLES)
+
+##########################################################################
+# Visualizing bundles and tract profiles:
+# ---------------------------------------
+# This would run the script and visualize the bundles using the plotly
+# interactive visualization, which should automatically open in a
+# new browser window.
+bundle_html = myafq.viz_bundles(export=True, n_points=50)
+plotly.io.show(bundle_html[0])

--- a/examples/plot_afq_reco80.py
+++ b/examples/plot_afq_reco80.py
@@ -9,8 +9,6 @@ An example using the AFQ API to run recobundles with the
 """
 import os.path as op
 
-import matplotlib.pyplot as plt
-import nibabel as nib
 import plotly
 
 from AFQ import api


### PR DESCRIPTION
This allows the user to also give callosal names when using bundle_info as a list. It also adds an example where we use the api to run pyAFQ with both sets of bundles. 

- [ ] find source of calossal bundles