### PR TITLE
Dilate the ROIs.

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1389,10 +1389,11 @@ class AFQ(object):
 
                 fname = op.join(rois_dir, fname[1])
                 if not op.exists(fname):
-
+                    from skimage.morphology import binary_dilation
+                    roi_data = binary_dilation(roi.get_fdata())
                     warped_roi = auv.patch_up_roi(
                         (mapping.transform_inverse(
-                            roi.get_fdata(),
+                            roi_data,
                             interpolation='linear')) > 0,
                         bundle_name=bundle).astype(int)
 

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1389,13 +1389,10 @@ class AFQ(object):
 
                 fname = op.join(rois_dir, fname[1])
                 if not op.exists(fname):
-                    from skimage.morphology import binary_dilation
-                    roi_data = binary_dilation(roi.get_fdata())
-                    warped_roi = auv.patch_up_roi(
-                        (mapping.transform_inverse(
-                            roi_data,
-                            interpolation='linear')) > 0,
-                        bundle_name=bundle).astype(int)
+                    warped_roi = auv.transform_inverse_roi(
+                        roi,
+                        mapping,
+                        bundle_name=bundle)
 
                     # Cast to float32, so that it can be read in by MI-Brain:
                     self.log_and_save_nii(

--- a/AFQ/mask.py
+++ b/AFQ/mask.py
@@ -287,10 +287,9 @@ class RoiMask(StrInstantiatesMixin):
         for bundle_name, bundle_info in afq_object.bundle_dict.items():
             for idx, roi in enumerate(bundle_info['ROIs']):
                 if afq_object.bundle_dict[bundle_name]['rules'][idx]:
-                    warped_roi = auv.patch_up_roi(
-                        mapping.transform_inverse(
-                            roi.get_fdata().astype(np.float32),
-                            interpolation='linear'),
+                    warped_roi = auv.transform_inverse_roi(
+                        roi,
+                        mapping,
                         bundle_name=bundle_name)
 
                     if mask_data is None:

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -420,10 +420,9 @@ class Segmentation:
         exclude_rois = []
         for rule_idx, rule in enumerate(rules):
             roi = self.bundle_dict[bundle]['ROIs'][rule_idx]
-            if not isinstance(roi, np.ndarray):
-                roi = roi.get_fdata()
-            warped_roi = auv.patch_up_roi(self.mapping.transform_inverse(
-                roi.astype(np.float32), interpolation='linear'),
+            warped_roi = auv.transform_inverse_roi(
+                roi,
+                self.mapping,
                 bundle_name=bundle)
 
             if rule:

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -18,7 +18,6 @@ import AFQ.tractography as aft
 import AFQ.registration as reg
 import AFQ.segmentation as seg
 import AFQ.models.dti as dti
-from AFQ.utils.volume import patch_up_roi
 
 
 dpd.fetch_stanford_hardi()

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -386,9 +386,9 @@ def prepare_roi(roi, affine_or_mapping, static_img,
                                                      static_img,
                                                      reg_template)
 
-            roi = auv.patch_up_roi(affine_or_mapping.transform_inverse(
-                                   roi,
-                                   interpolation='nearest')).astype(bool)
+            roi = auv.transform_inverse_roi(
+                roi,
+                affine_or_mapping).astype(bool)
     return roi
 
 
@@ -1351,7 +1351,7 @@ class GroupCSVComparison():
                 removal_idx,
                 axis=1)
         else:
-            is_removed_bundle = [False]*len(self.bundles)
+            is_removed_bundle = [False] * len(self.bundles)
 
         df_bundle_prof_means = pd.DataFrame(
             columns=['scalar', 'tractID', 'value'])

--- a/examples/optic_radiations.py
+++ b/examples/optic_radiations.py
@@ -11,6 +11,7 @@ ROIs of your design.
 For now, this is a hypothetical example, as we do not yet
 provide these ROIs as part of the software.
 """
+from dipy.data import get_fnames
 import os.path as op
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,7 +30,7 @@ import AFQ.registration as reg
 import AFQ.models.dti as dti
 import AFQ.models.csd as csd
 import AFQ.segmentation as seg
-from AFQ.utils.volume import patch_up_roi
+from AFQ.utils.volume import transform_inverse_roi
 
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -195,7 +196,6 @@ endpoint_spec = {
 # placed only within the inclusion ROIs. This allows us to oversample that
 # part of the brain, without having to deal with very large tractograms.
 
-from dipy.data import get_fnames
 f_pve_csf, f_pve_gm, f_pve_wm = get_fnames('stanford_pve_maps')
 
 pve_csf = nib.load(f_pve_csf)
@@ -207,10 +207,9 @@ if not op.exists(op.join(working_dir, 'pft_streamlines.trk')):
     seed_roi = np.zeros(img.shape[:-1])
     for bundle in bundles:
         for idx, roi in enumerate(bundles[bundle]['ROIs']):
-            warped_roi = patch_up_roi(
-                mapping.transform_inverse(
-                    roi.get_fdata().astype(np.float32),
-                    interpolation='linear'),
+            warped_roi = transform_inverse_roi(
+                roi,
+                mapping,
                 bundle_name=bundle)
             print(roi)
             nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),
@@ -227,10 +226,9 @@ if not op.exists(op.join(working_dir, 'pft_streamlines.trk')):
                                roi.affine,
                                MNI_T1w_img.affine)
 
-            warped_roi = patch_up_roi(
-                mapping.transform_inverse(
-                    roi.astype(np.float32),
-                    interpolation='linear'),
+            warped_roi = transform_inverse_roi(
+                roi,
+                mapping,
                 bundle_name=bundle)
 
             nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),

--- a/examples/plot_callosal_tract_profile.py
+++ b/examples/plot_callosal_tract_profile.py
@@ -38,7 +38,7 @@ import AFQ.tractography as aft
 import AFQ.registration as reg
 import AFQ.models.dti as dti
 import AFQ.segmentation as seg
-from AFQ.utils.volume import patch_up_roi, density_map
+from AFQ.utils.volume import transform_inverse_roi, density_map
 from AFQ.viz.utils import show_anatomical_slices
 from AFQ.viz.plotly_backend import visualize_bundles, visualize_volume
 
@@ -301,10 +301,9 @@ if not op.exists(op.join(working_dir, 'dti_streamlines.trk')):
     for bundle in bundles:
         for idx, roi in enumerate(bundles[bundle]['ROIs']):
             if bundles[bundle]['rules'][idx]:
-                warped_roi = patch_up_roi(
-                    mapping.transform_inverse(
-                        roi.get_fdata().astype(np.float32),
-                        interpolation='linear'),
+                warped_roi = transform_inverse_roi(
+                    roi,
+                    mapping,
                     bundle_name=bundle)
 
                 nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -26,7 +26,7 @@ import AFQ.tractography as aft
 import AFQ.registration as reg
 import AFQ.models.dti as dti
 import AFQ.segmentation as seg
-from AFQ.utils.volume import patch_up_roi
+from AFQ.utils.volume import transform_inverse_roi
 
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -124,10 +124,9 @@ if not op.exists(op.join(working_dir, 'dti_streamlines.trk')):
     for bundle in bundles:
         for idx, roi in enumerate(bundles[bundle]['ROIs']):
             if bundles[bundle]['rules'][idx]:
-                warped_roi = patch_up_roi(
-                    mapping.transform_inverse(
-                        roi.get_fdata().astype(np.float32),
-                        interpolation='linear'),
+                warped_roi = transform_inverse_roi(
+                    roi,
+                    mapping,
                     bundle_name=bundle)
 
                 nib.save(nib.Nifti1Image(warped_roi.astype(float), img.affine),


### PR DESCRIPTION
This avoids strange edge cases, where the one voxel thick ROIs get squished by the SyN mapping and nothing remains of them, raising an error from `patch_up_roi`. 