### PR TITLE
Reduce apm test workload

### DIFF
--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -358,7 +358,7 @@ def test_AFQ_anisotropic():
     npt.assert_equal(bvals_in_range_or_0, np.ones(160, dtype=bool))
 
     # check that the apm map was made
-    myafq.export_rois()
+    myafq.set_mapping()
     assert op.exists(op.join(
         myafq.data_frame['results_dir'][0],
         'sub-01_ses-01_dwi_model-CSD_APM.nii.gz'))


### PR DESCRIPTION
The only nightly failing now is nightly5. It contains one test: test_AFQ_anisotropic. That test passes locally. I wonder if the new way of calculating APM uses more memory? What's weird is this test does not even do tractography. This PR makes the test do even less, which will hopefully help it pass. 