### PR TITLE
Relax versions to avoid cvxpy/numpy incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     nibabel==3.0.2
     dipy>=1.2.0
     scipy>=1.2.0
-    numpy==1.20.0
+    numpy>=1.18.5,<1.20
     pandas==1.0.3
     joblib==0.16.0
     dask==1.1.0
@@ -51,7 +51,7 @@ install_requires =
     funcargparse==0.2.2
     packaging>=19.0
     seaborn==0.11.0
-    cvxpy==1.1.5
+    cvxpy>=1.1.10
     plotly==4.9.0
     psutil==5.7.0
     kaleido==0.0.3.post1


### PR DESCRIPTION
Some tools have issues with various version of numpy (e.g. [cvxpy](https://github.com/cvxgrp/cvxpy/issues/1229) versions before `1.1.10` were only compiled on pypi with numpy `1.20`), which can in turn cause a bunch of install issues.

This PR proposes that we relax the numpy requirement here, using a version that was fixed for pyafq 0.6 as the lower bound, and requiring the version stay below the latest minor release, 1.20, for the time being. We also update the cvxpy requirement to get past the fixed numpy issue from their side.

I've tested this in a config locally with numpy `1.19.1` and things work as expected.