### PR TITLE
Allow more flexibility in dask version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy>=1.18.5,<1.20
     pandas==1.0.3
     joblib==0.16.0
-    dask>=1.1.0
+    dask>=1.1.0,<=2021.2.0
     palettable==3.1.1
     cloudpickle==1.3.0
     toolz==0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy>=1.18.5,<1.20
     pandas==1.0.3
     joblib==0.16.0
-    dask==1.1.0
+    dask>=1.1.0
     palettable==3.1.1
     cloudpickle==1.3.0
     toolz==0.9.0


### PR DESCRIPTION
This is a problem in the context of our hub configuration, where we need a match between the versions of `dask` and `dask-distributed`.