### PR TITLE
[DO NOT MERGE] set numpy to 1.19.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     nibabel==3.0.2
     dipy>=1.2.0
     scipy>=1.2.0
-    numpy>=1.18.5,<1.20
+    numpy==1.19.1
     pandas==1.0.3
     joblib==0.16.0
     dask==1.1.0


### PR DESCRIPTION
This commit is just using the CI to try to reproduce a bug pyAFQ has, possible specific to this version of numpy.