### PR TITLE
Add conflict checker; loosen up dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev,fury]
+    - name: Check Dependencies
+      run: |
+        pipconflictchecker
     - name: Lint
       run: |
         flake8 --ignore N802,N806,W503 --select W504 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /docs/`

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,35 +26,35 @@ setup_requires =
   setuptools_scm
 python_requires = >=3.7
 install_requires =
-    scikit_image==0.16.2
-    nibabel==3.0.2
-    dipy>=1.2.0
-    scipy>=1.2.0
+    scikit_image>=0.16,<=0.18.*
+    nibabel>=3.0,<=3.2.*
+    dipy>=1.2,<=1.3.*
+    scipy>=1.2,<=1.6.*
     numpy>=1.18.5,<1.20
-    pandas==1.0.3
-    joblib==0.16.0
-    dask>=1.1.0,<=2021.2.0
-    palettable==3.1.1
-    cloudpickle==1.3.0
-    toolz==0.9.0
-    boto3==1.14.18
-    s3fs==0.4.2
-    tqdm==4.32.2
-    python-dateutil==2.8.1
-    toml==0.10.0
-    setuptools_scm[toml]==3.4.3
-    popylar==0.2
-    imageio==2.8.0
-    ipython==7.13.0
-    templateflow==0.6.2
-    pybids==0.11.1
-    funcargparse==0.2.2
-    packaging>=19.0
-    seaborn==0.11.0
-    cvxpy>=1.1.10
+    pandas>=1.0,<=1.2.*
+    joblib>=0.16,<=1.0.*
+    dask>=1.1,<=2021.2.0
+    palettable>=3.1,<=3.3.*
+    cloudpickle>=1.3,<=1.6.*
+    toolz>=0.9,<=0.11.*
+    boto3>=1.14.18,<=1.17.10
+    s3fs>=0.4,<=0.5.*
+    tqdm>=4.0,<=4.57.*
+    python-dateutil>=2.0,<=2.8.*
+    toml==0.10.*
+    setuptools_scm[toml]>=3.4,<=5.0.*
+    popylar==0.2.*
+    imageio>=2.8,<=2.9.*
+    templateflow>=0.6,<=0.7.*
+    pybids>=0.11,<=0.12.*
+    funcargparse==0.2.*
+    packaging>=19.0,<=20.9.*
+    seaborn==0.11.*
+    cvxpy==1.1.*
     plotly==4.9.0
-    psutil==5.7.0
+    psutil>=5.7,<=5.8.*
     kaleido==0.0.3.post1
+    pip-conflict-checker==0.6.*
 zip_safe = False
 include_package_data = True
 packages = find:
@@ -75,6 +75,7 @@ dev =
     xvfbwrapper==0.2.9
     moto==1.3.14
 fury =
+    ipython>=7.13.0,<=7.20.0
     vtk==9.0.1
     fury==0.6.0
     xvfbwrapper==0.2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,32 +27,32 @@ setup_requires =
 python_requires = >=3.7
 install_requires =
     scikit_image>=0.16.0,<0.19.0
-    nibabel>=3.0.0,<=3.2.*
-    dipy>=1.2.0,<=1.3.*
-    scipy>=1.2.0,<=1.6.*
+    nibabel>=3.0.0,<3.3.0
+    dipy>=1.2.0,<1.4.0
+    scipy>=1.2.0,<1.7.0
     numpy>=1.18.5,<1.20
-    pandas>=1.0.0,<=1.2.*
-    joblib>=0.16.0,<=1.0.*
+    pandas>=1.0.0,<1.3.0
+    joblib>=0.16.0,<1.1.0
     dask>=1.1,<=2021.2.0
-    palettable>=3.1.0,<=3.3.*
-    cloudpickle>=1.3.0,<=1.6.*
-    toolz>=0.9.0,<=0.11.*
+    palettable>=3.1.0,<3.4.0
+    cloudpickle>=1.3.0,<1.7.0
+    toolz>=0.9.0,<0.12.0
     boto3>=1.14.18,<=1.17.10
-    s3fs>=0.4.0,<=0.5.*
-    tqdm>=4.0.0,<=4.57.*
-    python-dateutil>=2.0.0,<=2.8.*
+    s3fs>=0.4.0,<0.6.0
+    tqdm>=4.0.0,<4.58.0
+    python-dateutil>=2.0.0,<2.9.0
     toml==0.10.*
-    setuptools_scm[toml]>=3.4.0,<=5.0.*
+    setuptools_scm[toml]>=3.4.0,<5.1.0
     popylar==0.2.*
-    imageio>=2.8.0,<=2.9.*
+    imageio>=2.8.0,<3.0.0
     templateflow==0.6.2
-    pybids>=0.11.0,<=0.12.*
+    pybids>=0.11.0,<0.13.0
     funcargparse==0.2.*
-    packaging>=19.0.0,<=20.9.*
+    packaging>=19.0.0,<21.0.0
     seaborn==0.11.*
     cvxpy==1.1.*
     plotly==4.9.0
-    psutil>=5.7.0,<=5.8.*
+    psutil>=5.7.0,<5.9.0
     kaleido==0.0.3.post1
     pip-conflict-checker==0.6.*
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,33 +26,33 @@ setup_requires =
   setuptools_scm
 python_requires = >=3.7
 install_requires =
-    scikit_image>=0.16,<=0.18.*
-    nibabel>=3.0,<=3.2.*
-    dipy>=1.2,<=1.3.*
-    scipy>=1.2,<=1.6.*
+    scikit_image>=0.16.0,<=0.18.*
+    nibabel>=3.0.0,<=3.2.*
+    dipy>=1.2.0,<=1.3.*
+    scipy>=1.2.0,<=1.6.*
     numpy>=1.18.5,<1.20
-    pandas>=1.0,<=1.2.*
-    joblib>=0.16,<=1.0.*
+    pandas>=1.0.0,<=1.2.*
+    joblib>=0.16.0,<=1.0.*
     dask>=1.1,<=2021.2.0
-    palettable>=3.1,<=3.3.*
-    cloudpickle>=1.3,<=1.6.*
-    toolz>=0.9,<=0.11.*
+    palettable>=3.1.0,<=3.3.*
+    cloudpickle>=1.3.0,<=1.6.*
+    toolz>=0.9.0,<=0.11.*
     boto3>=1.14.18,<=1.17.10
-    s3fs>=0.4,<=0.5.*
-    tqdm>=4.0,<=4.57.*
-    python-dateutil>=2.0,<=2.8.*
+    s3fs>=0.4.0,<=0.5.*
+    tqdm>=4.0.0,<=4.57.*
+    python-dateutil>=2.0.0,<=2.8.*
     toml==0.10.*
-    setuptools_scm[toml]>=3.4,<=5.0.*
+    setuptools_scm[toml]>=3.4.0,<=5.0.*
     popylar==0.2.*
-    imageio>=2.8,<=2.9.*
-    templateflow>=0.6,<=0.7.*
-    pybids>=0.11,<=0.12.*
+    imageio>=2.8.0,<=2.9.*
+    templateflow>=0.6.0,<=0.7.*
+    pybids>=0.11.0,<=0.12.*
     funcargparse==0.2.*
-    packaging>=19.0,<=20.9.*
+    packaging>=19.0.0,<=20.9.*
     seaborn==0.11.*
     cvxpy==1.1.*
     plotly==4.9.0
-    psutil>=5.7,<=5.8.*
+    psutil>=5.7.0,<=5.8.*
     kaleido==0.0.3.post1
     pip-conflict-checker==0.6.*
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
   setuptools_scm
 python_requires = >=3.7
 install_requires =
-    scikit_image>=0.16.0,<=0.18.*
+    scikit_image>=0.16.0,<0.19.0
     nibabel>=3.0.0,<=3.2.*
     dipy>=1.2.0,<=1.3.*
     scipy>=1.2.0,<=1.6.*
@@ -45,7 +45,7 @@ install_requires =
     setuptools_scm[toml]>=3.4.0,<=5.0.*
     popylar==0.2.*
     imageio>=2.8.0,<=2.9.*
-    templateflow>=0.6.0,<=0.7.*
+    templateflow==0.6.2
     pybids>=0.11.0,<=0.12.*
     funcargparse==0.2.*
     packaging>=19.0.0,<=20.9.*


### PR DESCRIPTION
I am trying to strike a balance here between only allowing versions we know work, and not being too strict about versions. 