### PR TITLE
Allow ItkMap in pyAFQ

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-# -*- coding: utf-8 -*-
 import logging
 from AFQ.definitions.mask import (B0Mask, ScalarMask, FullMask)
-from AFQ.definitions.mapping import (SynMap, FnirtMap)
+from AFQ.definitions.mapping import (SynMap, FnirtMap, ItkMap)
 from AFQ.definitions.utils import Definition
 from AFQ.utils.bin import get_default_args
 from AFQ.viz.utils import Viz, visualize_tract_profiles
@@ -44,7 +44,6 @@ import bids.config as bids_config
 bids_config.set_option('extension_initial_dot', True)
 
 
-bids.config.set_option('extension_initial_dot', True)
 logging.basicConfig(level=logging.INFO)
 
 
@@ -2140,7 +2139,8 @@ class AFQ(object):
     def export_all(self):
         """ Exports all the possible outputs"""
         start_time = time()
-        if not isinstance(self.mapping_definition, FnirtMap):
+        if not isinstance(self.mapping_definition, FnirtMap)\
+                and not isinstance(self.mapping_definition, ItkMap):
             self.export_registered_b0()
         self.get_template_xform()
         self.export_bundles()

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -121,7 +121,7 @@ class ConformedFnirtMapping():
 
 class ItkMap(Definition):
     """
-    Use an existing Itk map. Expects the warp file
+    Use an existing Itk map (e.g., from ANTS). Expects the warp file
     from MNI to T1.
 
     Parameters

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -17,6 +17,12 @@ try:
 except ModuleNotFoundError:
     has_fslpy = False
 
+try:
+    import h5py
+    has_h5py = True
+except ModuleNotFoundError:
+    has_h5py = False
+
 __all__ = ["FnirtMap", "SynMap", "SlrMap", "AffMap"]
 
 # For map defintions, get_for_row should return only the mapping
@@ -51,8 +57,8 @@ class FnirtMap(Definition):
     fnirt_map = FnirtMap(
         "warp",
         "MNI",
-        {"scope"="TBSS"},
-        {"scope"="TBSS"})
+        {"scope": "TBSS"},
+        {"scope": "TBSS"})
     api.AFQ(mapping=fnirt_map)
     """
 
@@ -111,6 +117,76 @@ class ConformedFnirtMapping():
         raise NotImplementedError(
             "Fnirt based mappings can currently"
             + " only transform from template to subject space")
+
+
+class ItkMap(Definition):
+    """
+    Use an existing Itk map. Expects the warp file
+    from MNI to T1.
+
+    Parameters
+    ----------
+    warp_suffix : str
+        suffix to pass to bids_layout.get() to identify the warp file.
+    warp_filters : str
+        Additional filters to pass to bids_layout.get() to identify
+        the warp file.
+        Default: {}
+
+
+    Examples
+    --------
+    itk_map = ItkMap(
+        "xfm",
+        {"scope": "qsiprep",
+        "from": "MNI152NLin2009cAsym",
+        "to": "T1w"})
+    api.AFQ(mapping=itk_map)
+    """
+
+    def __init__(self, warp_suffix, warp_filters={}):
+        if not has_h5py:
+            raise ImportError(
+                "Please install h5py if you want to use ItkMap")
+        self.warp_suffix = warp_suffix
+        self.warp_filters = warp_filters
+        self.fnames = {}
+
+    def find_path(self, bids_layout, from_path, subject, session):
+        if session not in self.fnames:
+            self.fnames[session] = {}
+
+        self.fnames[session][subject] = find_file(
+            bids_layout, from_path, self.warp_filters, self.warp_suffix,
+            session, subject, extension="h5")
+
+    def get_for_row(self, afq_object, row):
+        nearest_warp = self.fnames[row['ses']][row['subject']]
+        warp_f5 = h5py.File(nearest_warp)
+        their_shape = np.asarray(warp_f5["TransformGroup"]['1'][
+            'TransformFixedParameters'], dtype=int)[:3]
+        our_shape = afq_object.reg_template_img.get_fdata().shape
+        if (our_shape != their_shape).any():
+            raise ValueError((
+                f"The shape of your ITK mapping ({their_shape})"
+                f" is not the same as your template for registration"
+                f" ({our_shape})"))
+        their_forward = np.asarray(warp_f5["TransformGroup"]['1'][
+            'TransformParameters']).reshape([*their_shape, 3])
+        their_disp = np.zeros((*their_shape, 3, 2))
+        their_disp[..., 0] = their_forward
+        their_disp = nib.Nifti1Image(
+            their_disp, afq_object.reg_template_img.affine)
+        their_prealign = np.zeros((4, 4))
+        their_prealign[:3, :3] = np.asarray(warp_f5["TransformGroup"]["2"][
+            "TransformParameters"])[:9].reshape((3, 3))
+        their_prealign[:3, 3] = np.asarray(warp_f5["TransformGroup"]["2"][
+            "TransformParameters"])[9:]
+        their_prealign[3, 3] = 1.0
+        warp_f5.close()
+        return reg.read_mapping(
+            their_disp, row['dwi_file'],
+            afq_object.reg_template_img, prealign=their_prealign)
 
 
 class GeneratedMapMixin(object):

--- a/AFQ/definitions/mask.py
+++ b/AFQ/definitions/mask.py
@@ -85,7 +85,7 @@ class MaskFile(Definition):
     --------
     seed_mask = MaskFile(
         "WM_mask",
-        {"scope"="dmriprep"})
+        {"scope":"dmriprep"})
     api.AFQ(tracking_params={"seed_mask": seed_mask,
                                 "seed_threshold": 0.1})
     """
@@ -329,7 +329,7 @@ class ThresholdedMaskFile(MaskFile, CombineMaskMixin):
     --------
     brain_mask = ThresholdedMaskFile(
         "brain_mask",
-        {"scope"="dmriprep"},
+        {"scope":"dmriprep"},
         lower_bound=0.1)
     api.AFQ(brain_mask=brain_mask)
     """

--- a/AFQ/definitions/scalar.py
+++ b/AFQ/definitions/scalar.py
@@ -51,7 +51,7 @@ class ScalarFile(MaskFile):
     my_scalar = ScalarFile(
         "my_scalar",
         "scalarSuffix",
-        {"scope"="dmriprep"})
+        {"scope": "dmriprep"})
     api.AFQ(scalars=["dti_fa", "dti_md", my_scalar])
     """
 

--- a/AFQ/definitions/utils.py
+++ b/AFQ/definitions/utils.py
@@ -63,7 +63,8 @@ def _arglist_to_string(args, get_attr=None):
     return to_string
 
 
-def find_file(bids_layout, path, filters, suffix, session, subject):
+def find_file(bids_layout, path, filters, suffix, session, subject,
+              extension=".nii.gz"):
     """
     Helper function
     Generic calls to get_nearest to find a file
@@ -72,7 +73,7 @@ def find_file(bids_layout, path, filters, suffix, session, subject):
     nearest = bids_layout.get_nearest(
         path,
         **filters,
-        extension=".nii.gz",
+        extension=extension,
         suffix=suffix,
         session=session,
         subject=subject,
@@ -85,7 +86,7 @@ def find_file(bids_layout, path, filters, suffix, session, subject):
         nearest = bids_layout.get_nearest(
             path,
             **filters,
-            extension=".nii.gz",
+            extension=extension,
             suffix=suffix,
             subject=subject,
             full_search=True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,3 +79,7 @@ fury =
     vtk==9.0.1
     fury==0.6.0
     xvfbwrapper==0.2.9
+fsl = 
+    fslpy
+itk = 
+    h5py


### PR DESCRIPTION
Allows user to describe Itk map to use instead of our generated mappings. I tested its compatibility with a map from QSIprep. The example in the docstring should be helpful.

This touches a lot of files because I fixed a few dosctrings in other definitions.