### PR TITLE
[FIX] remove invalid sls from tractography, which could be custom

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1231,7 +1231,9 @@ class AFQ(object):
 
             img = nib.load(row['dwi_file'])
             tg = load_tractogram(
-                streamlines_file, img, Space.VOX)
+                streamlines_file, img, Space.VOX,
+                bbox_valid_check=False)
+            tg.remove_invalid_streamlines()
 
             start_time = time()
             segmentation = seg.Segmentation(**self.segmentation_params)


### PR DESCRIPTION
I will test this on the optic bids data