### PR TITLE
[ENH] A variety of registration improvements, primarily for babyAFQ

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -1703,7 +1703,7 @@ class AFQ(object):
                             pp.get_fdata(),
                             self.reg_template_img,
                             pp.affine,
-                            self.reg_template_img.affine)
+                            self.reg_template_img.affine).get_fdata()
 
                         atlas_roi = np.zeros(pp.shape)
                         atlas_roi[np.where(pp > 0)] = 1

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -6,7 +6,6 @@ from AFQ.definitions.utils import Definition
 from AFQ.utils.bin import get_default_args
 from AFQ.viz.utils import Viz, visualize_tract_profiles
 import AFQ.utils.volume as auv
-import AFQ.registration as reg
 import AFQ.segmentation as seg
 import AFQ.utils.streamlines as aus
 import dipy.reconst.dki as dpy_dki
@@ -34,6 +33,7 @@ import dipy.tracking.utils as dtu
 from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.align import resample
 from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.reconst import shm
 from dipy.reconst.dki_micro import axonal_water_fraction
@@ -1699,7 +1699,7 @@ class AFQ(object):
                     start_p = endpoint_info[bundle_name]['startpoint']
                     end_p = endpoint_info[bundle_name]['endpoint']
                     for ii, pp in enumerate([start_p, end_p]):
-                        pp = reg.resample(
+                        pp = resample(
                             pp.get_fdata(),
                             self.reg_template_img,
                             pp.affine,

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1,4 +1,4 @@
-import AFQ.registration as reg
+from dipy.align import resample
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import (AveragePointwiseEuclideanMetric,
                                  ResampleFeature)
@@ -173,10 +173,10 @@ def read_callosum_templates(resample_to=False):
         if resample_to:
             if isinstance(resample_to, str):
                 resample_to = nib.load(resample_to)
-            img = nib.Nifti1Image(reg.resample(img.get_fdata(),
-                                               resample_to,
-                                               img.affine,
-                                               resample_to.affine),
+            img = nib.Nifti1Image(resample(img.get_fdata(),
+                                           resample_to,
+                                           img.affine,
+                                           resample_to.affine),
                                   resample_to.affine)
         template_dict[f.split('.')[0]] = img
 
@@ -225,10 +225,11 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
     if np.allclose(resample_to.affine, roi.affine):
         return roi
 
-    as_array = reg.resample(roi.get_fdata(),
-                            resample_to,
-                            roi.affine,
-                            resample_to.affine)
+    as_array = resample(
+        roi.get_fdata(),
+        resample_to,
+        roi.affine,
+        resample_to.affine)
     if threshold:
         as_array = (as_array > threshold).astype(int)
 
@@ -411,11 +412,13 @@ def read_templates(resample_to=False):
         if resample_to:
             if isinstance(resample_to, str):
                 resample_to = nib.load(resample_to)
-            img = nib.Nifti1Image(reg.resample(img.get_fdata(),
-                                               resample_to,
-                                               img.affine,
-                                               resample_to.affine),
-                                  resample_to.affine)
+            img = nib.Nifti1Image(
+                resample(
+                    img.get_fdata(),
+                    resample_to,
+                    img.affine,
+                    resample_to.affine),
+                resample_to.affine)
         template_dict[f.split('.')[0]] = img
 
     toc = time.perf_counter()
@@ -1964,10 +1967,11 @@ def read_aal_atlas(resample_to=None):
         data = out_dict['atlas'].get_fdata()
         oo = []
         for ii in range(data.shape[-1]):
-            oo.append(reg.resample(data[..., ii],
-                                   resample_to,
-                                   out_dict['atlas'].affine,
-                                   resample_to.affine))
+            oo.append(resample(
+                data[..., ii],
+                resample_to,
+                out_dict['atlas'].affine,
+                resample_to.affine))
         out_dict['atlas'] = nib.Nifti1Image(np.stack(oo, -1),
                                             resample_to.affine)
     return out_dict
@@ -2314,10 +2318,11 @@ def _apply_mask(template_img, resolution=1):
 
     if mask_data.shape != template_data.shape:
         mask_img = nib.Nifti1Image(
-            reg.resample(mask_data,
-                         template_data,
-                         mask_img.affine,
-                         template_img.affine),
+            resample(
+                mask_data,
+                template_data,
+                mask_img.affine,
+                template_img.affine),
             template_img.affine)
         mask_data = mask_img.get_fdata()
 

--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -176,7 +176,7 @@ def read_callosum_templates(resample_to=False):
             img = nib.Nifti1Image(resample(img.get_fdata(),
                                            resample_to,
                                            img.affine,
-                                           resample_to.affine),
+                                           resample_to.affine).get_fdata(),
                                   resample_to.affine)
         template_dict[f.split('.')[0]] = img
 
@@ -229,7 +229,7 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
         roi.get_fdata(),
         resample_to,
         roi.affine,
-        resample_to.affine)
+        resample_to.affine).get_fdata()
     if threshold:
         as_array = (as_array > threshold).astype(int)
 
@@ -417,7 +417,7 @@ def read_templates(resample_to=False):
                     img.get_fdata(),
                     resample_to,
                     img.affine,
-                    resample_to.affine),
+                    resample_to.affine).get_fdata(),
                 resample_to.affine)
         template_dict[f.split('.')[0]] = img
 
@@ -1971,7 +1971,7 @@ def read_aal_atlas(resample_to=None):
                 data[..., ii],
                 resample_to,
                 out_dict['atlas'].affine,
-                resample_to.affine))
+                resample_to.affine).get_fdata())
         out_dict['atlas'] = nib.Nifti1Image(np.stack(oo, -1),
                                             resample_to.affine)
     return out_dict
@@ -2322,7 +2322,7 @@ def _apply_mask(template_img, resolution=1):
                 mask_data,
                 template_data,
                 mask_img.affine,
-                template_img.affine),
+                template_img.affine).get_fdata(),
             template_img.affine)
         mask_data = mask_img.get_fdata()
 

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -378,8 +378,8 @@ class ConformedAffineMapping(AffineMap):
 
     def transform(self, *args, interpolation='linear', **kwargs):
         kwargs['interp'] = interpolation
-        return super().transform_inverse(*args, **kwargs)
+        return super().transform(*args, **kwargs)
 
     def transform_inverse(self, *args, interpolation='linear', **kwargs):
         kwargs['interp'] = interpolation
-        return super().transform(*args, **kwargs)
+        return super().transform_inverse(*args, **kwargs)

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -373,7 +373,8 @@ class AffMap(GeneratedMapMixin, Definition):
 
     def gen_mapping(self, afq_object, row, reg_template_img, reg_template_sls,
                     reg_subject_img, reg_subject_sls, reg_prealign):
-        return ConformedAffineMapping(np.linalg.inv(self.prealign(afq_object, row, save=False)))
+        return ConformedAffineMapping(np.linalg.inv(
+            self.prealign(afq_object, row, save=False)))
 
 
 class ConformedAffineMapping(AffineMap):

--- a/AFQ/definitions/mask.py
+++ b/AFQ/definitions/mask.py
@@ -3,7 +3,7 @@ import numpy as np
 import nibabel as nib
 from dipy.segment.mask import median_otsu
 
-import AFQ.registration as reg
+from dipy.align import resample
 import AFQ.utils.volume as auv
 from AFQ.definitions.utils import Definition, find_file
 
@@ -25,10 +25,11 @@ def _resample_mask(mask_data, dwi_data, mask_affine, dwi_affine):
     if ((dwi_data is not None)
         and (dwi_affine is not None)
             and (dwi_data[..., 0].shape != mask_data.shape)):
-        return np.round(reg.resample(mask_data.astype(float),
-                                     dwi_data[..., 0],
-                                     mask_affine,
-                                     dwi_affine)).astype(mask_type)
+        return np.round(resample(
+            mask_data.astype(float),
+            dwi_data[..., 0],
+            mask_affine,
+            dwi_affine).get_fdata()).astype(mask_type)
     else:
         return mask_data
 

--- a/AFQ/definitions/scalar.py
+++ b/AFQ/definitions/scalar.py
@@ -98,7 +98,7 @@ class TemplateScalar(ScalarMixin, Definition):
                 self.img.get_fdata(),
                 afq_object.reg_template_img,
                 self.img.affine,
-                afq_object.reg_template_img.affine)
+                afq_object.reg_template_img.affine).get_fdata()
             self.is_resampled = True
 
         mapping = afq_object._mapping(row)

--- a/AFQ/definitions/scalar.py
+++ b/AFQ/definitions/scalar.py
@@ -1,11 +1,12 @@
 from AFQ.definitions.utils import Definition
 from AFQ.definitions.mask import MaskFile
 
-import AFQ.registration as reg
 import AFQ.data as afd
 
 import nibabel as nib
 import os.path as op
+
+from dipy.align import resample
 
 # For scalar defintions, get_for_row should return:
 # data, affine, meta
@@ -93,7 +94,7 @@ class TemplateScalar(ScalarMixin, Definition):
 
     def get_data(self, afq_object, row):
         if not self.is_resampled:
-            self.img = reg.resample(
+            self.img = resample(
                 self.img.get_fdata(),
                 afq_object.reg_template_img,
                 self.img.affine,

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -9,7 +9,8 @@ from dipy.align.imwarp import DiffeomorphicMap
 
 from dipy.align.imaffine import AffineMap
 
-from dipy.align import syn_registration
+from dipy.align import (syn_registration, center_of_mass, translation,
+                        rigid, affine, register_series, )
 
 import dipy.core.gradients as dpg
 from dipy.align.streamlinear import whole_brain_slr
@@ -19,6 +20,16 @@ from AFQ.definitions.mapping import ConformedAffineMapping
 
 __all__ = ["syn_register_dwi", "write_mapping", "read_mapping",
            "register_dwi", "slr_registration"]
+
+
+def reduce_shape(shape):
+    """
+    Reduce dimension in shape to 3 if possible
+    """
+    try:
+        return shape[:3]
+    except TypeError:
+        return shape
 
 
 def syn_register_dwi(dwi, gtab, template=None, **syn_kwargs):
@@ -143,7 +154,7 @@ def read_mapping(disp, domain_img, codomain_img, prealign=None):
 
 def register_dwi(data_files, bval_files, bvec_files,
                  b0_ref=0,
-                 pipeline=[c_of_mass, translation, rigid, affine],
+                 pipeline=[center_of_mass, translation, rigid, affine],
                  out_dir=None):
     """
     Register a DWI data-set

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -16,7 +16,6 @@ import dipy.core.gradients as dpg
 from dipy.align.streamlinear import whole_brain_slr
 
 import AFQ.utils.models as mut
-from AFQ.definitions.mapping import ConformedAffineMapping
 
 __all__ = ["syn_register_dwi", "write_mapping", "read_mapping",
            "register_dwi", "slr_registration"]
@@ -140,6 +139,7 @@ def read_mapping(disp, domain_img, codomain_img, prealign=None):
         mapping.backward = disp_data[..., 1]
         mapping.is_inverse = True
     else:
+        from AFQ.definitions.mapping import ConformedAffineMapping
         mapping = ConformedAffineMapping(
             disp,
             domain_grid_shape=reduce_shape(
@@ -231,6 +231,8 @@ def slr_registration(moving_data, static_data,
     -------
     AffineMap
     """
+    from AFQ.definitions.mapping import ConformedAffineMapping
+
     _, transform, _, _ = whole_brain_slr(
         static_data, moving_data, x0='affine', verbose=False, **kwargs)
 

--- a/AFQ/registration.py
+++ b/AFQ/registration.py
@@ -5,98 +5,20 @@ import os
 import os.path as op
 import numpy as np
 import nibabel as nib
-from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
-from dipy.align.imwarp import (SymmetricDiffeomorphicRegistration,
-                               DiffeomorphicMap)
+from dipy.align.imwarp import DiffeomorphicMap
 
-from dipy.align.imaffine import (transform_centers_of_mass,
-                                 MutualInformationMetric,
-                                 AffineRegistration, AffineMap)
+from dipy.align.imaffine import AffineMap
 
-from dipy.align.transforms import (TranslationTransform3D,
-                                   RigidTransform3D,
-                                   AffineTransform3D)
+from dipy.align import syn_registration
 
 import dipy.core.gradients as dpg
-import dipy.data as dpd
-from dipy.align.streamlinear import \
-    StreamlineLinearRegistration, whole_brain_slr
-from dipy.tracking.streamline import set_number_of_points
-from dipy.tracking.utils import transform_tracking_output
-from dipy.io.streamline import load_tractogram, load_trk
+from dipy.align.streamlinear import whole_brain_slr
 
 import AFQ.utils.models as mut
-import AFQ.utils.streamlines as sut
 from AFQ.definitions.mapping import ConformedAffineMapping
 
-syn_metric_dict = {'CC': CCMetric,
-                   'EM': EMMetric,
-                   'SSD': SSDMetric}
-
-__all__ = ["syn_registration", "syn_register_dwi", "write_mapping",
-           "read_mapping", "resample", "c_of_mass", "translation", "rigid",
-           "affine", "affine_registration", "register_series", "register_dwi",
-           "streamline_registration"]
-
-
-def syn_registration(moving, static,
-                     moving_affine=None,
-                     static_affine=None,
-                     step_length=0.25,
-                     metric='CC',
-                     dim=3,
-                     level_iters=[10, 10, 5],
-                     sigma_diff=2.0,
-                     radius=4,
-                     prealign=None):
-    """Register a source image (moving) to a target image (static).
-
-    Parameters
-    ----------
-    moving : ndarray
-        The source image data to be registered
-    moving_affine : array, shape (4,4)
-        The affine matrix associated with the moving (source) data.
-    static : ndarray
-        The target image data for registration
-    static_affine : array, shape (4,4)
-        The affine matrix associated with the static (target) data
-    metric : string, optional
-        The metric to be optimized. One of `CC`, `EM`, `SSD`,
-        Default: CCMetric.
-    dim: int (either 2 or 3), optional
-       The dimensions of the image domain. Default: 3
-    level_iters : list of int, optional
-        the number of iterations at each level of the Gaussian Pyramid (the
-        length of the list defines the number of pyramid levels to be
-        used).
-    sigma_diff, radius : float
-        Parameters for initialization of the metric.
-
-    Returns
-    -------
-    warped_moving : ndarray
-        The data in `moving`, warped towards the `static` data.
-    forward : ndarray (..., 3)
-        The vector field describing the forward warping from the source to the
-        target.
-    backward : ndarray (..., 3)
-        The vector field describing the backward warping from the target to the
-        source.
-    """
-    use_metric = syn_metric_dict[metric](dim, sigma_diff=sigma_diff,
-                                         radius=radius)
-
-    sdr = SymmetricDiffeomorphicRegistration(use_metric, level_iters,
-                                             step_length=step_length)
-
-    mapping = sdr.optimize(static, moving,
-                           static_grid2world=static_affine,
-                           moving_grid2world=moving_affine,
-                           prealign=prealign)
-
-    warped_moving = mapping.transform(moving)
-    return warped_moving, mapping
+__all__ = ["syn_register_dwi", "write_mapping", "read_mapping",
+           "register_dwi", "slr_registration"]
 
 
 def syn_register_dwi(dwi, gtab, template=None, **syn_kwargs):
@@ -219,154 +141,6 @@ def read_mapping(disp, domain_img, codomain_img, prealign=None):
     return mapping
 
 
-def resample(moving, static, moving_affine, static_affine):
-    """Resample an image from one space to another.
-
-    Parameters
-    ----------
-    moving : array
-       The image to be resampled
-
-    static : array
-
-    moving_affine
-    static_affine
-
-    Returns
-    -------
-    resampled : the moving array resampled into the static array's space.
-    """
-    identity = np.eye(4)
-    affine_map = AffineMap(identity,
-                           static.shape, static_affine,
-                           moving.shape, moving_affine)
-    resampled = affine_map.transform(moving)
-    return resampled
-
-
-# Affine registration pipeline:
-affine_metric_dict = {'MI': MutualInformationMetric}
-
-
-def c_of_mass(moving, static, static_affine, moving_affine,
-              reg, starting_affine, params0=None):
-    transform = transform_centers_of_mass(static, static_affine,
-                                          moving, moving_affine)
-    transformed = transform.transform(moving)
-    return transformed, transform.affine
-
-
-def translation(moving, static, static_affine, moving_affine,
-                reg, starting_affine, params0=None):
-    transform = TranslationTransform3D()
-    translation = reg.optimize(static, moving, transform, params0,
-                               static_affine, moving_affine,
-                               starting_affine=starting_affine)
-
-    return translation.transform(moving), translation.affine
-
-
-def rigid(moving, static, static_affine, moving_affine,
-          reg, starting_affine, params0=None):
-    transform = RigidTransform3D()
-    rigid = reg.optimize(static, moving, transform, params0,
-                         static_affine, moving_affine,
-                         starting_affine=starting_affine)
-    return rigid.transform(moving), rigid.affine
-
-
-def affine(moving, static, static_affine, moving_affine,
-           reg, starting_affine, params0=None):
-    transform = AffineTransform3D()
-    affine = reg.optimize(static, moving, transform, params0,
-                          static_affine, moving_affine,
-                          starting_affine=starting_affine)
-
-    return affine.transform(moving), affine.affine
-
-
-def affine_registration(moving, static,
-                        moving_affine=None,
-                        static_affine=None,
-                        nbins=32,
-                        sampling_prop=None,
-                        metric='MI',
-                        pipeline=[c_of_mass, translation, rigid, affine],
-                        level_iters=[10000, 1000, 100],
-                        sigmas=[5.0, 2.5, 0.0],
-                        factors=[4, 2, 1],
-                        params0=None):
-    """
-    Find the affine transformation between two 3D images.
-
-    Parameters
-    ----------
-
-    """
-    # Define the Affine registration object we'll use with the chosen metric:
-    use_metric = affine_metric_dict[metric](nbins, sampling_prop)
-    affreg = AffineRegistration(metric=use_metric,
-                                level_iters=level_iters,
-                                sigmas=sigmas,
-                                factors=factors)
-
-    # Bootstrap this thing with the identity:
-    starting_affine = np.eye(4)
-    # Go through the selected transformation:
-    for func in pipeline:
-        transformed, starting_affine = func(moving, static,
-                                            static_affine,
-                                            moving_affine,
-                                            affreg, starting_affine,
-                                            params0)
-    return transformed, starting_affine
-
-
-def register_series(series, ref, pipeline):
-    """Register a series to a reference image.
-
-    Parameters
-    ----------
-    series : Nifti1Image object
-       The data is 4D with the last dimension separating different 3D volumes
-    ref : Nifti1Image or integer or iterable
-
-    Returns
-    -------
-    transformed_list, affine_list
-    """
-    if isinstance(ref, nib.Nifti1Image):
-        static = ref
-        static_data = static.get_fdata()
-        s_aff = static.affine
-        moving = series
-        moving_data = moving.get_fdata()
-        m_aff = moving.affine
-
-    elif isinstance(ref, int) or np.iterable(ref):
-        data = series.get_fdata()
-        idxer = np.zeros(data.shape[-1]).astype(bool)
-        idxer[ref] = True
-        static_data = data[..., idxer]
-        if len(static_data.shape) > 3:
-            static_data = np.mean(static_data, -1)
-        moving_data = data[..., ~idxer]
-        m_aff = s_aff = series.affine
-
-    affine_list = []
-    transformed_list = []
-    for ii in range(moving_data.shape[-1]):
-        this_moving = moving_data[..., ii]
-        transformed, affine = affine_registration(this_moving, static_data,
-                                                  moving_affine=m_aff,
-                                                  static_affine=s_aff,
-                                                  pipeline=pipeline)
-        transformed_list.append(transformed)
-        affine_list.append(affine)
-
-    return transformed_list, affine_list
-
-
 def register_dwi(data_files, bval_files, bvec_files,
                  b0_ref=0,
                  pipeline=[c_of_mass, translation, rigid, affine],
@@ -417,61 +191,6 @@ def register_dwi(data_files, bval_files, bvec_files,
     path = op.join(out_dir, 'registered.nii.gz')
     nib.save(reg_img, path)
     return path
-
-
-def streamline_registration(moving, static, n_points=100,
-                            native_resampled=False):
-    """
-    Register two collections of streamlines ('bundles') to each other
-
-    Parameters
-    ----------
-    moving, static : lists of 3 by n, or str
-        The two bundles to be registered. Given either as lists of arrays with
-        3D coordinates, or strings containing full paths to these files.
-
-    n_points : int, optional
-        How many points to resample to. Default: 100.
-
-    native_resampled : bool, optional
-        Whether to return the moving bundle in the original space, but
-        resampled in the static space to n_points.
-
-    Returns
-    -------
-    aligned : list
-        Streamlines from the moving group, moved to be closely matched to
-        the static group.
-
-    matrix : array (4, 4)
-        The affine transformation that takes us from 'moving' to 'static'
-    """
-    # Load the streamlines, if you were given a file-name
-    if isinstance(moving, str):
-        moving = load_trk(moving, 'same', bbox_valid_check=False).streamlines
-    if isinstance(static, str):
-        static = load_trk(static, 'same', bbox_valid_check=False).streamlines
-
-    srr = StreamlineLinearRegistration()
-    srm = srr.optimize(static=set_number_of_points(static, n_points),
-                       moving=set_number_of_points(moving, n_points))
-
-    aligned = srm.transform(moving)
-    if native_resampled:
-        aligned = set_number_of_points(aligned, n_points)
-        aligned = transform_tracking_output(aligned, np.linalg.inv(srm.matrix))
-
-    return aligned, srm.matrix
-
-
-def reduce_shape(shape):
-    """
-    Reduce dimension in shape to 3 if possible
-    """
-    try:
-        return shape[:3]
-    except TypeError:
-        return shape
 
 
 def slr_registration(moving_data, static_data,

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -17,6 +17,7 @@ from dipy.stats.analysis import gaussian_weights
 import dipy.core.gradients as dpg
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.streamline import save_tractogram
+from dipy.align import resample
 
 import AFQ.registration as reg
 import AFQ.utils.models as ut
@@ -715,10 +716,11 @@ class Segmentation:
 
                     atlas_idx = []
                     for ii, pp in enumerate([start_p, end_p]):
-                        pp = reg.resample(pp.get_fdata(),
-                                          self.reg_template,
-                                          pp.affine,
-                                          self.reg_template.affine)
+                        pp = resample(
+                            pp.get_fdata(),
+                            self.reg_template,
+                            pp.affine,
+                            self.reg_template.affine)
 
                         atlas_roi = np.zeros(pp.shape)
                         atlas_roi[np.where(pp > 0)] = 1

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -720,7 +720,7 @@ class Segmentation:
                             pp.get_fdata(),
                             self.reg_template,
                             pp.affine,
-                            self.reg_template.affine)
+                            self.reg_template.affine).get_fdata()
 
                         atlas_roi = np.zeros(pp.shape)
                         atlas_roi[np.where(pp > 0)] = 1

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -27,7 +27,6 @@ from AFQ import api
 import AFQ.data as afd
 import AFQ.segmentation as seg
 import AFQ.utils.streamlines as aus
-import AFQ.registration as reg
 import AFQ.utils.bin as afb
 from AFQ.definitions.mask import RoiMask, ThresholdedScalarMask,\
     PFTMask, MaskFile

--- a/AFQ/tests/test_registration.py
+++ b/AFQ/tests/test_registration.py
@@ -16,6 +16,8 @@ import AFQ.data as afd
 
 from dipy.io.streamline import load_tractogram
 from dipy.io.stateful_tractogram import Space
+from dipy.align.imwarp import DiffeomorphicMap
+
 
 MNI_T2 = afd.read_mni_template()
 hardi_img, gtab = dpd.read_stanford_hardi()

--- a/AFQ/tests/test_registration.py
+++ b/AFQ/tests/test_registration.py
@@ -7,19 +7,15 @@ import nibabel as nib
 import nibabel.tmpdirs as nbtmp
 
 import dipy.data as dpd
-import dipy.core.gradients as dpg
 
-from AFQ.registration import (syn_registration, register_series, register_dwi,
-                              c_of_mass, translation, rigid, affine,
-                              streamline_registration, write_mapping,
-                              read_mapping, syn_register_dwi, DiffeomorphicMap,
+from AFQ.registration import (register_dwi, write_mapping,
+                              read_mapping, syn_register_dwi,
                               slr_registration)
 
 import AFQ.data as afd
 
-from dipy.tracking.utils import transform_tracking_output
-from dipy.io.streamline import load_trk, save_trk, load_tractogram
-from dipy.io.stateful_tractogram import StatefulTractogram, Space
+from dipy.io.streamline import load_tractogram
+from dipy.io.stateful_tractogram import Space
 
 MNI_T2 = afd.read_mni_template()
 hardi_img, gtab = dpd.read_stanford_hardi()
@@ -37,37 +33,6 @@ subset_dwi_data = nib.Nifti1Image(hardi_data[40:50, 40:50, 40:50],
 subset_t2 = MNI_T2_data[40:60, 40:60, 40:60]
 subset_b0_img = nib.Nifti1Image(subset_b0, hardi_affine)
 subset_t2_img = nib.Nifti1Image(subset_t2, MNI_T2_affine)
-
-
-def test_syn_registration():
-    with nbtmp.InTemporaryDirectory() as tmpdir:
-        warped_moving, mapping = syn_registration(subset_b0,
-                                                  subset_t2,
-                                                  moving_affine=hardi_affine,
-                                                  static_affine=MNI_T2_affine,
-                                                  step_length=0.1,
-                                                  metric='CC',
-                                                  dim=3,
-                                                  level_iters=[5, 5, 5],
-                                                  sigma_diff=2.0,
-                                                  radius=1,
-                                                  prealign=None)
-
-        npt.assert_equal(warped_moving.shape, subset_t2.shape)
-        mapping_fname = op.join(tmpdir, 'mapping.nii.gz')
-        write_mapping(mapping, mapping_fname)
-        file_mapping = read_mapping(mapping_fname,
-                                    subset_b0_img,
-                                    subset_t2_img)
-
-        # Test that it has the same effect on the data:
-        warped_from_file = file_mapping.transform(subset_b0)
-        npt.assert_equal(warped_from_file, warped_moving)
-
-        # Test that it is, attribute by attribute, identical:
-        for k in mapping.__dict__:
-            assert (np.all(mapping.__getattribute__(k) ==
-                           file_mapping.__getattribute__(k)))
 
 
 def test_slr_registration():
@@ -125,19 +90,6 @@ def test_syn_register_dwi():
     npt.assert_equal(warped_b0.shape, subset_t2_img.shape)
 
 
-def test_register_series():
-    fdata, fbval, fbvec = dpd.get_fnames('small_64D')
-    img = nib.load(fdata)
-    gtab = dpg.gradient_table(fbval, fbvec)
-    ref_idx = np.where(gtab.b0s_mask)
-    transformed_list, affine_list = register_series(img,
-                                                    ref=ref_idx,
-                                                    pipeline=[c_of_mass,
-                                                              translation,
-                                                              rigid,
-                                                              affine])
-
-
 def test_register_dwi():
     fdata, fbval, fbvec = dpd.get_fnames('small_64D')
     with nbtmp.InTemporaryDirectory() as tmpdir:
@@ -156,52 +108,3 @@ def test_register_dwi():
                                 op.join(tmpdir, 'bvecs.txt'))
         npt.assert_(op.exists(reg_file))
 
-
-def test_streamline_registration():
-    sl1 = [np.array([[0, 0, 0], [0, 0, 0.5], [0, 0, 1], [0, 0, 1.5]]),
-           np.array([[0, 0, 0], [0, 0.5, 0.5], [0, 1, 1]])]
-    affine = np.eye(4)
-    affine[:3, 3] = np.random.randn(3)
-    sl2 = list(transform_tracking_output(sl1, affine))
-    aligned, matrix = streamline_registration(sl2, sl1)
-    npt.assert_almost_equal(matrix, np.linalg.inv(affine))
-    npt.assert_almost_equal(aligned[0], sl1[0])
-    npt.assert_almost_equal(aligned[1], sl1[1])
-
-    # We assume the two tracks come from the same space, but it might have
-    # some affine associated with it:
-    base_aff = np.eye(4) * np.random.rand()
-    base_aff[:3, 3] = np.array([1, 2, 3])
-    base_aff[3, 3] = 1
-
-    with nbtmp.InTemporaryDirectory() as tmpdir:
-        for use_aff in [None, base_aff]:
-            fname1 = op.join(tmpdir, 'sl1.trk')
-            fname2 = op.join(tmpdir, 'sl2.trk')
-            if use_aff is not None:
-                img = nib.Nifti1Image(np.zeros((2, 2, 2)), use_aff)
-                # Move the streamlines to this other space, and report it:
-                tgm1 = StatefulTractogram(
-                    transform_tracking_output(sl1, np.linalg.inv(use_aff)),
-                    img,
-                    Space.VOX)
-
-                save_trk(tgm1, fname1, bbox_valid_check=False)
-
-                tgm2 = StatefulTractogram(
-                    transform_tracking_output(sl2, np.linalg.inv(use_aff)),
-                    img,
-                    Space.VOX)
-
-                save_trk(tgm2, fname2, bbox_valid_check=False)
-
-            else:
-                img = nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4))
-                tgm1 = StatefulTractogram(sl1, img, Space.RASMM)
-                tgm2 = StatefulTractogram(sl2, img, Space.RASMM)
-                save_trk(tgm1, fname1, bbox_valid_check=False)
-                save_trk(tgm2, fname2, bbox_valid_check=False)
-
-            aligned, matrix = streamline_registration(fname2, fname1)
-            npt.assert_almost_equal(aligned[0], sl1[0], decimal=5)
-            npt.assert_almost_equal(aligned[1], sl1[1], decimal=5)

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -15,7 +15,6 @@ from dipy.io.stateful_tractogram import StatefulTractogram, Space
 
 import AFQ.data as afd
 import AFQ.tractography as aft
-import AFQ.registration as reg
 import AFQ.segmentation as seg
 import AFQ.models.dti as dti
 

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -5,6 +5,7 @@ import dipy.reconst.shm as shm
 import logging
 
 import dipy.data as dpd
+from dipy.align import resample
 from dipy.direction import (DeterministicMaximumDirectionGetter,
                             ProbabilisticDirectionGetter)
 import dipy.tracking.utils as dtu
@@ -16,8 +17,6 @@ from dipy.tracking.stopping_criterion import (ThresholdStoppingCriterion,
 
 from AFQ._fixes import (VerboseLocalTracking, VerboseParticleFilteringTracking,
                         tensor_odf)
-
-import AFQ.registration as reg
 
 
 def track(params_file, directions="det", max_angle=30., sphere=None,
@@ -185,15 +184,18 @@ def track(params_file, directions="det", max_angle=30., sphere=None,
         average_voxel_size = np.mean(vox_sizes)
         pve_wm_img, pve_gm_img, pve_csf_img = pve_imgs
         pve_wm_data, pve_gm_data, pve_csf_data = pves
-        pve_wm_data = reg.resample(pve_wm_data, model_params[..., 0],
-                                   pve_wm_img.affine,
-                                   params_img.affine)
-        pve_gm_data = reg.resample(pve_gm_data, model_params[..., 0],
-                                   pve_gm_img.affine,
-                                   params_img.affine)
-        pve_csf_data = reg.resample(pve_csf_data, model_params[..., 0],
-                                    pve_csf_img.affine,
-                                    params_img.affine)
+        pve_wm_data = resample(
+            pve_wm_data, model_params[..., 0],
+            pve_wm_img.affine,
+            params_img.affine)
+        pve_gm_data = resample(
+            pve_gm_data, model_params[..., 0],
+            pve_gm_img.affine,
+            params_img.affine)
+        pve_csf_data = resample(
+            pve_csf_data, model_params[..., 0],
+            pve_csf_img.affine,
+            params_img.affine)
 
         vox_sizes.append(np.mean(params_img.header.get_zooms()[:3]))
 

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -187,15 +187,15 @@ def track(params_file, directions="det", max_angle=30., sphere=None,
         pve_wm_data = resample(
             pve_wm_data, model_params[..., 0],
             pve_wm_img.affine,
-            params_img.affine)
+            params_img.affine).get_fdata()
         pve_gm_data = resample(
             pve_gm_data, model_params[..., 0],
             pve_gm_img.affine,
-            params_img.affine)
+            params_img.affine).get_fdata()
         pve_csf_data = resample(
             pve_csf_data, model_params[..., 0],
             pve_csf_img.affine,
-            params_img.affine)
+            params_img.affine).get_fdata()
 
         vox_sizes.append(np.mean(params_img.header.get_zooms()[:3]))
 

--- a/AFQ/utils/volume.py
+++ b/AFQ/utils/volume.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import scipy.ndimage as ndim
 from skimage.filters import gaussian
-from skimage.morphology import convex_hull_image, binary_dilation
+from skimage.morphology import binary_dilation
 from scipy.spatial.qhull import QhullError
 from scipy.spatial.distance import dice
 
@@ -14,6 +14,7 @@ from dipy.tracking.streamline import select_random_set_of_streamlines
 import dipy.tracking.utils as dtu
 
 logger = logging.getLogger('AFQ.utils.volume')
+
 
 def transform_inverse_roi(roi, mapping, bundle_name="ROI"):
     """
@@ -46,7 +47,8 @@ def transform_inverse_roi(roi, mapping, bundle_name="ROI"):
     _roi = mapping.transform_inverse(roi, interpolation='linear')
 
     if np.sum(_roi) == 0:
-        logger.warning(f'Lost ROI {bundle_name}, performing automatic binary dilation')
+        logger.warning(
+            f'Lost ROI {bundle_name}, performing automatic binary dilation')
         _roi = binary_dilation(roi)
         _roi = mapping.transform_inverse(_roi, interpolation='linear')
 
@@ -55,7 +57,7 @@ def transform_inverse_roi(roi, mapping, bundle_name="ROI"):
     return _roi
 
 
-def patch_up_roi(roi, bundle_name="ROI"):
+def patch_up_roi(roi, bundle_name="ROI", make_convex=True):
     """
     After being non-linearly transformed, ROIs tend to have holes in them.
     We perform a couple of computational geometry operations on the ROI to
@@ -86,10 +88,7 @@ def patch_up_roi(roi, bundle_name="ROI"):
         raise ValueError((
             f"{bundle_name} found to be empty after "
             "applying the mapping."))
-    try:
-        return convex_hull_image(hole_filled)
-    except QhullError:
-        return hole_filled
+    return hole_filled
 
 
 def density_map(tractogram, n_sls=None, to_vox=False, normalize=False):

--- a/AFQ/utils/volume.py
+++ b/AFQ/utils/volume.py
@@ -44,13 +44,13 @@ def transform_inverse_roi(roi, mapping, bundle_name="ROI"):
         roi = roi.get_fdata()
 
     _roi = mapping.transform_inverse(roi, interpolation='linear')
-    _roi = patch_up_roi(_roi > 0, bundle_name=bundle_name).astype(int)
 
     if np.sum(_roi) == 0:
         logger.warning(f'Lost ROI {bundle_name}, performing automatic binary dilation')
         _roi = binary_dilation(roi)
         _roi = mapping.transform_inverse(_roi, interpolation='linear')
-        _roi = patch_up_roi(_roi > 0, bundle_name=bundle_name).astype(int)
+
+    _roi = patch_up_roi(_roi > 0, bundle_name=bundle_name).astype(int)
 
     return _roi
 

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -20,6 +20,7 @@ from dipy.io.streamline import load_tractogram
 from dipy.tracking.utils import transform_tracking_output
 import dipy.tracking.streamlinespeed as dps
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
+from dipy.align import resample
 
 import AFQ.utils.volume as auv
 import AFQ.registration as reg
@@ -382,7 +383,7 @@ def prepare_roi(roi, affine_or_mapping, static_img,
                                  "need to also specify all of the following",
                                  "inputs: `static_img`, `roi_affine`, ",
                                  "`static_affine`")
-            roi = reg.resample(roi, static_img, roi_affine, static_affine)
+            roi = resample(roi, static_img, roi_affine, static_affine)
         else:
             # Assume it is  a mapping:
             if (isinstance(affine_or_mapping, str)

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -383,7 +383,8 @@ def prepare_roi(roi, affine_or_mapping, static_img,
                                  "need to also specify all of the following",
                                  "inputs: `static_img`, `roi_affine`, ",
                                  "`static_affine`")
-            roi = resample(roi, static_img, roi_affine, static_affine)
+            roi = resample(roi, static_img, roi_affine,
+                           static_affine).get_fdata()
         else:
             # Assume it is  a mapping:
             if (isinstance(affine_or_mapping, str)

--- a/examples/optic_radiations.py
+++ b/examples/optic_radiations.py
@@ -226,7 +226,7 @@ if not op.exists(op.join(working_dir, 'pft_streamlines.trk')):
                 roi.get_fdata(),
                 MNI_T1w_img,
                 roi.affine,
-                MNI_T1w_img.affine)
+                MNI_T1w_img.affine).get_fdata()
 
             warped_roi = transform_inverse_roi(
                 roi,

--- a/examples/optic_radiations.py
+++ b/examples/optic_radiations.py
@@ -23,6 +23,7 @@ from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
 from dipy.reconst import shm
+from dipy.align import affine_registration, resample
 
 import AFQ.data as afd
 import AFQ.tractography as aft
@@ -100,7 +101,7 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     import dipy.core.gradients as dpg
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)
     # Prealign using affine registration
-    _, prealign = reg.affine_registration(
+    _, prealign = affine_registration(
         apm,
         MNI_T1w_img.get_fdata(),
         img.affine,
@@ -221,10 +222,11 @@ if not op.exists(op.join(working_dir, 'pft_streamlines.trk')):
 
         for ii, pp in enumerate(endpoint_spec[bundle].keys()):
             roi = endpoint_spec[bundle][pp]
-            roi = reg.resample(roi.get_fdata(),
-                               MNI_T1w_img,
-                               roi.affine,
-                               MNI_T1w_img.affine)
+            roi = resample(
+                roi.get_fdata(),
+                MNI_T1w_img,
+                roi.affine,
+                MNI_T1w_img.affine)
 
             warped_roi = transform_inverse_roi(
                 roi,

--- a/examples/plot_callosal_tract_profile.py
+++ b/examples/plot_callosal_tract_profile.py
@@ -32,6 +32,7 @@ from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
+from dipy.align import affine_registration
 
 import AFQ.data as afd
 import AFQ.tractography as aft
@@ -165,7 +166,7 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)
     b0 = np.mean(img.get_fdata()[..., gtab.b0s_mask], -1)
     # Prealign using affine registration
-    _, prealign = reg.affine_registration(
+    _, prealign = affine_registration(
         b0,
         MNI_T2_img.get_fdata(),
         img.affine,

--- a/examples/plot_recobundles.py
+++ b/examples/plot_recobundles.py
@@ -25,6 +25,7 @@ from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
+from dipy.align import affine_registration
 
 
 import AFQ.data as afd
@@ -65,7 +66,7 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)
     b0 = np.mean(img.get_fdata()[..., gtab.b0s_mask], -1)
     # Prealign using affine registration
-    _, prealign = reg.affine_registration(
+    _, prealign = affine_registration(
         b0,
         MNI_T2_img.get_fdata(),
         img.affine,

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -19,6 +19,7 @@ from dipy.io.streamline import save_tractogram, load_tractogram
 from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.io.stateful_tractogram import StatefulTractogram
 from dipy.io.stateful_tractogram import Space
+from dipy.align import affine_registration
 
 from AFQ import api
 import AFQ.data as afd
@@ -84,7 +85,7 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     gtab = dpg.gradient_table(hardi_fbval, hardi_fbvec)
     b0 = np.mean(img.get_fdata()[..., gtab.b0s_mask], -1)
     # Prealign using affine registration
-    _, prealign = reg.affine_registration(
+    _, prealign = affine_registration(
         b0,
         MNI_T2_img.get_fdata(),
         img.affine,


### PR DESCRIPTION
This PR:
1. use dipy functions instead of some of the functions we have in afq.registration . We moved afq.registration functions to dipy but have not started using the dipy functions yet. This PR gets the low hanging fruit. 
2. Give user the option to pass kwargs to slr and syn registration
3. Fixes AffMap to actually apply the correct affine
4. removes convex hull adjustment for transformed ROIs. This was dilating them.