### PR TITLE
[FIX] Build and push pyAFQ docker image only after merge

### DIFF
--- a/.github/workflows/docker_pyafq.yml
+++ b/.github/workflows/docker_pyafq.yml
@@ -1,6 +1,13 @@
 name: Build and Push pyAFQ Docker Image
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - main
+
 
 jobs:
   build:


### PR DESCRIPTION
This is because there is no way to give PRs access to secrets.