### PR TITLE
[FIX] Minor BF for nightly tests

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -2216,12 +2216,12 @@ class AFQ(object):
         self.export_bundles()
         self.export_sl_counts()
         self.get_tract_profiles()
+        if len(self.tract_profiles) > 1:
+            self.combine_profiles()
         self.viz_bundles(export=True)
         if self.seg_algo == "afq":
             self.viz_ROIs(export=True)
             self.export_rois()
-        if len(self.tract_profiles) > 1:
-            self.combine_profiles()
         all_sub_sess = time() - start_time
         self.export_timing(all_sub_sess=all_sub_sess)
 

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -319,7 +319,7 @@ class SlrMap(GeneratedMapMixin, Definition):
     Calculate a SLR registration for each subject/session
     using reg_subject and reg_template.
 
-    syn_kwargs : dictionary, optional
+    slr_kwargs : dictionary, optional
         Parameters to pass to whole_brain_slr
         in dipy, which does the SLR alignment.
         Default: {}
@@ -329,8 +329,8 @@ class SlrMap(GeneratedMapMixin, Definition):
     api.AFQ(mapping=SlrMap())
     """
 
-    def __init__(self, syn_kwargs={}):
-        self.syn_kwargs = {}
+    def __init__(self, slr_kwargs={}):
+        self.slr_kwargs = {}
         self.use_prealign = False
         self.extension = ".npy"
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -292,10 +292,10 @@ def test_AFQ_init():
 
         if n_subjects != n_sessions:
             npt.assert_equal(my_afq.data_frame.shape,
-                             (n_subjects * n_sessions, 13))
+                             (n_subjects * n_sessions, 12))
         else:
             npt.assert_equal(my_afq.data_frame.shape,
-                             (n_subjects, 13))
+                             (n_subjects, 12))
 
 
 def test_AFQ_custom_bundle_dict():


### PR DESCRIPTION
One is a copy/paste typo in SLR map.

The other is that when sl counts was removed from the AFQ object data_frame, the corresponding test had to be updated.

Also a minor change in the order of export all, so that the profiles are combined right after they are generated.