### PR TITLE
[ENH] Provide more informative errors for incorrect BIDS structure, generate bundle dict lazily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         flake8 --ignore N802,N806,W503 --select W504 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /docs/`
     - name: Test
       run: |
-        cd && mkdir for_test && cd for_test && pytest --pyargs AFQ --cov-report term-missing --cov=AFQ -m "not nightly and not nightly_basic and not nightly_msmt_and_init and not nightly_custom and not nightly_anisotropic and not nightly_slr and not nightly_pft" --durations=0
+        cd && mkdir for_test && cd for_test && pytest --pyargs AFQ --cov-report term-missing --cov=AFQ -m "not nightly and not nightly_basic and not nightly_msmt_and_init and not nightly_custom and not nightly_anisotropic and not nightly_slr and not nightly_pft and not nightly_reco" --durations=0

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -122,7 +122,8 @@ class BundleDict(MutableMapping):
                     expanded_bundle_names.append(bundle_name + "_R")
                     expanded_bundle_names.append(bundle_name + "_L")
             elif self.seg_algo.startswith("reco"):
-                if bundle_name in RECO_UNIQUE:
+                if bundle_name in RECO_UNIQUE\
+                        or bundle_name == "whole_brain":
                     expanded_bundle_names.append(bundle_name)
                 else:
                     expanded_bundle_names.append(bundle_name + "_R")

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -270,6 +270,9 @@ class BundleDict(MutableMapping):
     def __iter__(self):
         return iter(self._dict)
 
+    def copy(self):
+        return self._dict.copy()
+
 
 # this is parallelized below
 def _getter_helper(wf_dict, attr_name):

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -25,6 +25,7 @@ import s3fs
 from time import time
 import nibabel as nib
 from importlib import import_module
+from collections.abc import MutableMapping
 
 from bids.layout import BIDSLayout
 import bids.config as bids_config
@@ -71,7 +72,7 @@ RECO_UNIQUE = [
 DIPY_GH = "https://github.com/dipy/dipy/blob/master/dipy/"
 
 
-class BundleDict(dict):
+class BundleDict(MutableMapping):
     def __init__(self,
                  bundle_info=BUNDLES,
                  seg_algo="afq",
@@ -236,7 +237,7 @@ class BundleDict(dict):
             self._list_to_dict()
 
         if self.seg_algo == "afq" and self.resample_to:
-            self.bundle_dict_resampled = {}
+            self.bundle_dict_resampled = self.bundle_dict_unresampled.copy()
             for bundle in self.bundle_dict_unresampled:
                 rois = self.bundle_dict_unresampled[bundle]['ROIs']
                 for ii, roi in enumerate(rois):
@@ -265,21 +266,6 @@ class BundleDict(dict):
 
     def __delitem__(self, key):
         del self._dict[key]
-
-    def has_key(self, k):
-        return k in self._dict
-
-    def keys(self):
-        return self._dict.keys()
-
-    def values(self):
-        return self._dict.values()
-
-    def items(self):
-        return self._dict.items()
-
-    def __contains__(self, item):
-        return item in self._dict
 
     def __iter__(self):
         return iter(self._dict)

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -103,6 +103,7 @@ class BundleDict(MutableMapping):
             raise TypeError((
                 f"bundle_info must be a dict or a list,"
                 f" currently a {type(bundle_info)}"))
+        self.seg_algo = seg_algo.lower()
 
         if isinstance(bundle_info, dict):
             self.bundle_names = list(bundle_info.keys())
@@ -130,7 +131,6 @@ class BundleDict(MutableMapping):
                         % self.seg_algo)
             self.bundle_names = expanded_bundle_names
             self._dict = {}
-        self.seg_algo = seg_algo.lower()
 
         # Each bundles gets a digit identifier
         # (to be stored in the tractogram)

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -581,6 +581,20 @@ class AFQ(object):
         bids_layout = BIDSLayout(bids_path, derivatives=True)
         bids_description = bids_layout.description
 
+        # check that any files exist in the derivatives folder,
+        # not including the dataset_description.json files
+        # the second check may be particularly useful in checking
+        # that the derivatives folder is well-defined
+        if len(bids_layout.get())\
+                - len(bids_layout.get(extension="json")) < 1:
+            raise ValueError(
+                f"No non-json files recognized by pyBIDS in {bids_path}")
+        if len(bids_layout.get(scope=dmriprep))\
+                - len(bids_layout.get(scope=dmriprep, extension="json")) < 1:
+            raise ValueError((
+                f"No non-json files recognized by "
+                f"pyBIDS in the pipeline: {dmriprep}"))
+
         # Add required metadata file at top level (inheriting as needed):
         pipeline_description = {
             "Name": bids_description["Name"],

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -396,9 +396,10 @@ class AFQ(object):
             If "median", the median of values at each node will be used
             instead of a mean or weighted mean.
             Default: "gauss"
-        bundle_info : list of strings or dict, optional
+        bundle_info : list of strings, dict, or BundleDict, optional
             [BUNDLES] List of bundle names to include in segmentation,
-            or a bundle dictionary (see BundleDict for inspiration).
+            or a bundle dictionary (see BundleDict for inspiration),
+            or a BundleDict.
             If None, will get all appropriate bundles for the chosen
             segmentation algorithm.
             Default: None
@@ -512,9 +513,11 @@ class AFQ(object):
         if bundle_info is not None and not ((
                 isinstance(bundle_info, list)
                 and isinstance(bundle_info[0], str)) or (
-                    isinstance(bundle_info, dict))):
-            raise TypeError(
-                "bundle_info must be None, a list of strings, or a dict")
+                    isinstance(bundle_info, dict)) or (
+                        isinstance(bundle_info, BundleDict))):
+            raise TypeError((
+                "bundle_info must be None, a list of strings,"
+                " a dict, or a BundleDict"))
         if not isinstance(parallel_params, dict):
             raise TypeError("parallel_params must be a dict")
         if scalars is not None and not (
@@ -630,10 +633,13 @@ class AFQ(object):
         # set reg_template and bundle_info:
         self.reg_template_img = self.get_reg_template()
         self.bundle_info = bundle_info
-        self.bundle_dict = BundleDict(
-            bundle_info,
-            seg_algo=self.seg_algo,
-            resample_to=self.reg_template_img)
+        if isinstance(bundle_info, BundleDict):
+            self.bundle_dict = bundle_info
+        else:
+            self.bundle_dict = BundleDict(
+                bundle_info,
+                seg_algo=self.seg_algo,
+                resample_to=self.reg_template_img)
 
         if not (isinstance(
                 self.segmentation_params["presegment_bundle_dict"],

--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -274,8 +274,7 @@ class BundleDict(MutableMapping):
         return self._dict[key]
 
     def __len__(self):
-        self.gen_all()
-        return len(self._dict)
+        return len(self.bundle_names)
 
     def __delitem__(self, key):
         if key in self._dict:

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -25,7 +25,7 @@ import AFQ.utils.volume as auv
 import AFQ.data as afd
 from AFQ.utils.parallel import parfor
 
-__all__ = ["Segmentation", "clean_bundles", "clean_by_endpoints"]
+__all__ = ["Segmentation", "clean_bundle", "clean_by_endpoints"]
 
 
 def _resample_tg(tg, n_points):
@@ -96,7 +96,7 @@ class Segmentation:
         clip_edges : bool
             Whether to clip the streamlines to be only in between the ROIs.
             Default: False
-        parallel_segmentation : dict
+        parallel_segmentation : dict or AFQ.api.BundleDict
             How to parallelize segmentation across processes when performing
             waypoint ROI segmentation. Set to {"engine": "serial"} to not
             perform parallelization. See ``AFQ.utils.parallel.pafor`` for
@@ -271,7 +271,7 @@ class Segmentation:
         [Yeatman2012]_ or RecoBundles [Garyfallidis2017]_.
         Parameters
         ----------
-        bundle_dict: dict
+        bundle_dict: dict or AFQ.api.BundleDict
             Meta-data for the segmentation. The format is something like::
                 {'name': {'ROIs':[img1, img2],
                 'rules':[True, True]},

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -913,7 +913,8 @@ class Segmentation:
             rb = RecoBundles(self.moved_sl, verbose=False, rng=self.rng)
         # Next we'll iterate over bundles, registering each one:
         bundle_list = list(self.bundle_dict.keys())
-        bundle_list.remove('whole_brain')
+        if 'whole_brain' in bundle_list:
+            bundle_list.remove('whole_brain')
 
         self.logger.info("Assigning Streamlines to Bundles")
         for bundle in bundle_list:

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -211,10 +211,17 @@ def test_BundleDict():
     assert len(afq_bundles) == 2
 
     # Vertical Occipital Fasciculus
-    # not included and does not exist in templates
-    afq_bundles = api.BundleDict(["VOF"], seg_algo="reco80")
+    # not included and does not exist in afq templates
+    with pytest.raises(
+            ValueError,
+            match="VOF_R is not in AFQ templates"):
+        api.BundleDict(["VOF"])
 
-    assert len(afq_bundles) == 0
+    afq_bundles = api.BundleDict(["VOF"], seg_algo="reco80")
+    assert len(afq_bundles) == 2
+
+    afq_bundles = api.BundleDict(["whole_brain"], seg_algo="reco80")
+    assert len(afq_bundles) == 1
 
 
 def test_AFQ_missing_files():

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -2,6 +2,7 @@ import tempfile
 import os
 import os.path as op
 import shutil
+import subprocess
 
 import toml
 
@@ -770,7 +771,7 @@ def test_AFQ_data_waypoint():
         toml.dump(config, ff)
 
     cmd = "pyAFQ " + config_file
-    out = os.system(cmd)
+    out = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     assert out == 0
     # The tract profiles should already exist from the CLI Run:
     from_file = pd.read_csv(tract_profile_fname)

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -251,9 +251,8 @@ def test_AFQ_missing_files():
 
     with pytest.raises(
             ValueError,
-            match=\
-                "No non-json files recognized by pyBIDS"
-                + " in the pipeline: missingPipe"):
+            match="No non-json files recognized by pyBIDS"
+            + " in the pipeline: missingPipe"):
         api.AFQ(bids_path, dmriprep="missingPipe")
 
     os.mkdir(op.join(bids_path, "missingPipe"))
@@ -263,9 +262,8 @@ def test_AFQ_missing_files():
             "PipelineDescription": {"Name": "missingPipe"}})
     with pytest.raises(
             ValueError,
-            match=\
-                "No non-json files recognized by pyBIDS"
-                + " in the pipeline: missingPipe"):
+            match="No non-json files recognized by pyBIDS"
+            + " in the pipeline: missingPipe"):
         api.AFQ(bids_path, dmriprep="missingPipe")
 
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -458,7 +458,9 @@ def test_API_type_checking():
 
     with pytest.raises(
             TypeError,
-            match="bundle_info must be None, a list of strings, or a dict"):
+            match=(
+                "bundle_info must be None, a list of strings,"
+                " a dict, or a BundleDict")):
         api.AFQ(bids_path, bundle_info=[2, 3])
 
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -3,6 +3,7 @@ import os
 import os.path as op
 import shutil
 import subprocess
+import gc
 
 import toml
 
@@ -773,6 +774,7 @@ def test_AFQ_data_waypoint():
     # save memory
     results_dir = myafq.results_dir["01"]
     del myafq
+    gc.collect()
 
     cmd = "pyAFQ " + config_file
     out = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -770,6 +770,10 @@ def test_AFQ_data_waypoint():
     with open(config_file, 'w') as ff:
         toml.dump(config, ff)
 
+    # save memory
+    results_dir = myafq.results_dir["01"]
+    del myafq
+
     cmd = "pyAFQ " + config_file
     out = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     assert out == 0
@@ -780,15 +784,13 @@ def test_AFQ_data_waypoint():
     assert_series_equal(tract_profiles['dti_fa'], from_file['dti_fa'])
 
     # Make sure the CLI did indeed generate these:
-    myafq.rois
     assert op.exists(op.join(
-        myafq.results_dir["01"],
+        results_dir,
         'ROIs',
         'sub-01_ses-01_dwi_desc-ROI-CST_R-1-include.json'))
 
-    myafq.indiv_bundles
     assert op.exists(op.join(
-        myafq.results_dir["01"],
+        results_dir,
         'bundles',
         'sub-01_ses-01_dwi_space-RASMM_model-DTI_desc-det-AFQ-CST_L_tractography.trk'))  # noqa
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -215,7 +215,8 @@ def test_BundleDict():
     with pytest.raises(
             ValueError,
             match="VOF_R is not in AFQ templates"):
-        api.BundleDict(["VOF"])
+        afq_bundles = api.BundleDict(["VOF"])
+        afq_bundles["VOF_R"]
 
     afq_bundles = api.BundleDict(["VOF"], seg_algo="reco80")
     assert len(afq_bundles) == 2

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -174,13 +174,13 @@ def create_dummy_bids_path(n_subjects, n_sessions, share_sessions=True):
     return bids_dir
 
 
-def test_make_bundle_dict():
+def test_BundleDict():
     """
     Tests bundle dict
     """
 
     # test defaults
-    afq_bundles = api.make_bundle_dict()
+    afq_bundles = api.BundleDict()
 
     # bundles restricted within hemisphere
     # NOTE: FA and FP cross midline so are removed
@@ -193,24 +193,24 @@ def test_make_bundle_dict():
     assert len(afq_bundles) == num_hemi_bundles + num_whole_bundles
 
     # Arcuate Fasciculus
-    afq_bundles = api.make_bundle_dict(bundle_names=["ARC"])
+    afq_bundles = api.BundleDict(bundle_names=["ARC"])
 
     assert len(afq_bundles) == 2
 
     # Forceps Minor
-    afq_bundles = api.make_bundle_dict(bundle_names=["FA"])
+    afq_bundles = api.BundleDict(bundle_names=["FA"])
 
     assert len(afq_bundles) == 1
 
     # Cingulum Hippocampus
     # not included but exists in templates
-    afq_bundles = api.make_bundle_dict(bundle_names=["HCC"])
+    afq_bundles = api.BundleDict(bundle_names=["HCC"])
 
     assert len(afq_bundles) == 2
 
     # Vertical Occipital Fasciculus
     # not included and does not exist in templates
-    afq_bundles = api.make_bundle_dict(bundle_names=["VOF"])
+    afq_bundles = api.BundleDict(bundle_names=["VOF"])
 
     assert len(afq_bundles) == 0
 
@@ -362,7 +362,7 @@ def test_AFQ_init():
 
 def test_AFQ_custom_bundle_dict():
     bids_path = create_dummy_bids_path(3, 1)
-    bundle_dict = api.make_bundle_dict()
+    bundle_dict = api.BundleDict()()
     api.AFQ(
         bids_path,
         dmriprep="synthetic",

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -212,7 +212,7 @@ def test_BundleDict():
 
     # Vertical Occipital Fasciculus
     # not included and does not exist in templates
-    afq_bundles = api.BundleDict(["VOF"])
+    afq_bundles = api.BundleDict(["VOF"], seg_algo="reco80")
 
     assert len(afq_bundles) == 0
 
@@ -777,8 +777,12 @@ def test_AFQ_data_waypoint():
     gc.collect()
 
     cmd = "pyAFQ " + config_file
-    out = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
-    assert out == 0
+    completed_process = subprocess.run(
+        cmd, shell=True, capture_output=True)
+    if completed_process.returncode != 0:
+        print(completed_process.stdout)
+    print(completed_process.stderr)
+    assert completed_process.returncode == 0
     # The tract profiles should already exist from the CLI Run:
     from_file = pd.read_csv(tract_profile_fname)
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -193,24 +193,24 @@ def test_BundleDict():
     assert len(afq_bundles) == num_hemi_bundles + num_whole_bundles
 
     # Arcuate Fasciculus
-    afq_bundles = api.BundleDict(bundle_names=["ARC"])
+    afq_bundles = api.BundleDict(["ARC"])
 
     assert len(afq_bundles) == 2
 
     # Forceps Minor
-    afq_bundles = api.BundleDict(bundle_names=["FA"])
+    afq_bundles = api.BundleDict(["FA"])
 
     assert len(afq_bundles) == 1
 
     # Cingulum Hippocampus
     # not included but exists in templates
-    afq_bundles = api.BundleDict(bundle_names=["HCC"])
+    afq_bundles = api.BundleDict(["HCC"])
 
     assert len(afq_bundles) == 2
 
     # Vertical Occipital Fasciculus
     # not included and does not exist in templates
-    afq_bundles = api.BundleDict(bundle_names=["VOF"])
+    afq_bundles = api.BundleDict(["VOF"])
 
     assert len(afq_bundles) == 0
 
@@ -362,7 +362,7 @@ def test_AFQ_init():
 
 def test_AFQ_custom_bundle_dict():
     bids_path = create_dummy_bids_path(3, 1)
-    bundle_dict = api.BundleDict()()
+    bundle_dict = api.BundleDict()
     api.AFQ(
         bids_path,
         dmriprep="synthetic",

--- a/examples/plot_recobundles.py
+++ b/examples/plot_recobundles.py
@@ -83,7 +83,7 @@ else:
 
 
 bundle_names = ["CST", "UF", "CC_ForcepsMajor", "CC_ForcepsMinor", "OR", "VOF"]
-bundles = api.BundleDict(bundle_names=bundle_names, seg_algo="reco80")
+bundles = api.BundleDict(bundle_names, seg_algo="reco80")
 
 print("Tracking...")
 if not op.exists(op.join(working_dir, 'dti_streamlines_reco.trk')):

--- a/examples/plot_recobundles.py
+++ b/examples/plot_recobundles.py
@@ -83,7 +83,7 @@ else:
 
 
 bundle_names = ["CST", "UF", "CC_ForcepsMajor", "CC_ForcepsMinor", "OR", "VOF"]
-bundles = api.make_bundle_dict(bundle_names=bundle_names, seg_algo="reco80")
+bundles = api.BundleDict(bundle_names=bundle_names, seg_algo="reco80")
 
 print("Tracking...")
 if not op.exists(op.join(working_dir, 'dti_streamlines_reco.trk')):
@@ -99,15 +99,17 @@ if not op.exists(op.join(working_dir, 'dti_streamlines_reco.trk')):
             sl_xform = [sum(d, s) for d, s in zip(delta, sl_xform)]
 
             sl_xform = dts.Streamlines(
-                dtu.transform_tracking_output(sl_xform,
-                np.linalg.inv(MNI_T2_img.affine)))
+                dtu.transform_tracking_output(
+                    sl_xform,
+                    np.linalg.inv(MNI_T2_img.affine)))
 
             sft = StatefulTractogram(sl_xform, img, Space.RASMM)
             save_tractogram(sft, op.join(working_dir, f'{bundle}_atlas.trk'))
 
             sl_xform = dts.Streamlines(
-                dtu.transform_tracking_output(sl_xform,
-                                        np.linalg.inv(img.affine)))
+                dtu.transform_tracking_output(
+                    sl_xform,
+                    np.linalg.inv(img.affine)))
 
             for sl in sl_xform:
                 sl_as_idx = sl.astype(int)

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -109,8 +109,9 @@ else:
 # they are brought into the subject's individual native space.
 # For speed, we only segment two bundles here.
 
-bundles = api.make_bundle_dict(bundle_names=["CST", "ARC"],
-                               resample_to=MNI_T2_img)
+bundles = api.BundleDict(
+    bundle_names=["CST", "ARC"],
+    resample_to=MNI_T2_img)
 
 
 ##########################################################################
@@ -134,8 +135,9 @@ if not op.exists(op.join(working_dir, 'dti_streamlines.trk')):
                          op.join(working_dir, f"{bundle}_{idx+1}.nii.gz"))
                 # Add voxels that aren't there yet:
                 seed_roi = np.logical_or(seed_roi, warped_roi)
-    nib.save(nib.Nifti1Image(seed_roi.astype(float), img.affine),
-                             op.join(working_dir, 'seed_roi.nii.gz'))
+    nib.save(nib.Nifti1Image(
+        seed_roi.astype(float), img.affine),
+        op.join(working_dir, 'seed_roi.nii.gz'))
     sft = aft.track(dti_params['params'], seed_mask=seed_roi,
                     stop_mask=FA_data, stop_threshold=0.1)
     save_tractogram(sft, op.join(working_dir, 'dti_streamlines.trk'),

--- a/examples/plot_tract_profile.py
+++ b/examples/plot_tract_profile.py
@@ -109,9 +109,7 @@ else:
 # they are brought into the subject's individual native space.
 # For speed, we only segment two bundles here.
 
-bundles = api.BundleDict(
-    bundle_names=["CST", "ARC"],
-    resample_to=MNI_T2_img)
+bundles = api.BundleDict(["CST", "ARC"], resample_to=MNI_T2_img)
 
 
 ##########################################################################


### PR DESCRIPTION
This provides informative errors if no files are found inside the entire BIDS layout or in the specific derivatives folder, which would be a result of incorrect BIDS structure.

The added test adds ~5 minutes to the test because initializing api.AFQ objects takes ~1.5 minutes each.