### PR TITLE
BF: Only generate warped endpoint ROIs if there are endpoint ROIs to use

### DIFF
--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -191,11 +191,11 @@ def viz_indivBundle(subses_dict,
                         aal_roi[targ[:, 0],
                                 targ[:, 1],
                                 targ[:, 2]] = 1
-                    warped_roi = auv.transform_inverse_roi(
-                        aal_roi,
-                        mapping,
-                        bundle_name=bundle_name)
-                    warped_rois.append(warped_roi)
+                        warped_roi = auv.transform_inverse_roi(
+                            aal_roi,
+                            mapping,
+                            bundle_name=bundle_name)
+                        warped_rois.append(warped_roi)
             for i, roi in enumerate(warped_rois):
                 figure = viz_backend.visualize_roi(
                     roi,

--- a/examples/plot_afq_callosal.py
+++ b/examples/plot_afq_callosal.py
@@ -40,15 +40,23 @@ tracking_params = dict(seed_mask=RoiMask(),
 # Initialize an AFQ object:
 # -------------------------
 #
-# We specify bundle_info as the default bundles list (api.BUNDLES) plus the
-# callosal bundle list. This tells the AFQ object to use bundles from both
+# We specify bundle_info as the callosal bundles only
+# (`api.CALLOSUM_BUNDLES`). If we want to segment both the callosum
+# and the other bundles, we would pass `api.CALLOSUM_BUNDLES + api.BUNDLES`
+# instead. This would tell the AFQ object to use bundles from both
 # the standard and callosal templates.
 
 myafq = api.AFQ(bids_path=op.join(afd.afq_home,
                                   'stanford_hardi'),
                 dmriprep='vistasoft',
-                bundle_info=api.BUNDLES + api.CALLOSUM_BUNDLES,
-                tracking_params=tracking_params)
+                bundle_info=api.CALLOSUM_BUNDLES,
+                tracking_params=tracking_params,
+                viz_backend='plotly_no_gif')
+
+# Calling export all produces all of the outputs of processing, including
+# tractography, scalar maps, tract profiles and visualizations:
+myafq.export_all()
+
 
 ##########################################################################
 # Visualizing bundles and tract profiles:


### PR DESCRIPTION
When deindented this block of code can raise something like the following error, when used in the context of bundles that don't have endpoint AAL ROIs (e.g., callosal bundles):

```
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/AFQ/api.py", line 949, in export_all
    self.indiv_bundles_figures
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/AFQ/api.py", line 899, in __getattribute__
    _getter_helper(wf_dict, attr_name)
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/AFQ/api.py", line 207, in _getter_helper
    return wf_dict[attr_name]
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/pimms/calculation.py", line 466, in __getitem__
    self._run_node(self.plan.efferents[k])
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/pimms/calculation.py", line 530, in _run_node
    if not found: res = node(self)
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/pimms/calculation.py", line 87, in __call__
    result = self.function(*args)
  File "/mnt/batch/tasks/shared/miniconda/lib/python3.8/site-packages/AFQ/tasks/viz.py", line 195, in viz_indivBundle
    aal_roi,
UnboundLocalError: local variable 'aal_roi' referenced before assignment
```