### PR TITLE
Move AAL atlas to figshare

### DIFF
--- a/AFQ/data.py
+++ b/AFQ/data.py
@@ -1927,10 +1927,9 @@ fetch_aal_atlas = _make_fetcher(
     "fetch_aal_atlas",
     op.join(afq_home,
             'aal_atlas'),
-    'https://digital.lib.washington.edu' + '/researchworks'
-    + '/bitstream/handle/1773/44951/',
-    ["MNI_AAL_AndMore.nii.gz",
-     "MNI_AAL.txt"],
+    'https://ndownloader.figshare.com/files/',
+    ["28416852",
+     "28416855"],
     ["MNI_AAL_AndMore.nii.gz",
      "MNI_AAL.txt"],
     md5_list=["69395b75a16f00294a80eb9428bf7855",


### PR DESCRIPTION
When the UW library's website is down for maintenance (as it is right now), the AAL atlas, which is stored there, becomes inaccessible, and pyAFQ raises an error when it tries to find it (but only on new installations, for example in ephemeral cloud computing resources). I am hoping that figshare is less likely to go down for maintenance without providing an alternative.