### PR TITLE
BF: loop over valid_sub and valid_ses lists correctly

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -998,20 +998,21 @@ class AFQ(object):
         in_list = []
         to_calc_list = []
         results = {}
-        for subject in self.valid_sub_list:
-            results[subject] = {}
-            for session in self.valid_ses_list:
-                wf_dict = self.wf_dict[subject][str(session)]
-                if section is not None:
-                    wf_dict = wf_dict[section]
-                if ((self.parallel_params.get("engine", False) != "serial")
-                        and (hasattr(wf_dict, "efferents"))
-                        and (attr_name not in wf_dict.efferents)):
-                    in_list.append((wf_dict))
-                    to_calc_list.append((subject, session))
-                else:
-                    results[subject][session] =\
-                        _getter_helper(wf_dict, attr_name)
+        for ii, subject in enumerate(self.valid_sub_list):
+            if subject not in results:
+                results[subject] = {}
+            session = self.valid_ses_list[ii]
+            wf_dict = self.wf_dict[subject][str(session)]
+            if section is not None:
+                wf_dict = wf_dict[section]
+            if ((self.parallel_params.get("engine", False) != "serial")
+                    and (hasattr(wf_dict, "efferents"))
+                    and (attr_name not in wf_dict.efferents)):
+                in_list.append((wf_dict))
+                to_calc_list.append((subject, session))
+            else:
+                results[subject][session] =\
+                    _getter_helper(wf_dict, attr_name)
 
         # if some need to be calculated, do those in parallel
         if len(to_calc_list) > 0:


### PR DESCRIPTION
This fixes a bug introduce in the Pimms PR. The master code in api.AFQ.__getattribute__ has a bug, it iterates over every subject in valid_sub_list and then for each subject iterates over every session in valid_ses_list. The valid sub and ses lists are not constructed this way, however, because not every subject is in every session. The master code is redundant and may lead to subject/session combinations that are not valid. 