### PR TITLE
BF: Fix config file reader for new params

### DIFF
--- a/AFQ/utils/bin.py
+++ b/AFQ/utils/bin.py
@@ -4,7 +4,6 @@ import datetime
 import platform
 import os.path as op
 import os
-import logging
 
 from argparse import ArgumentParser
 from funcargparse import FuncArgParser
@@ -13,7 +12,8 @@ from AFQ.definitions.mask import *  # interprets masks loaded from toml
 from AFQ.definitions.mapping import *  # interprets mappings loaded from toml
 from AFQ.definitions.scalar import *  # interprets scalars loaded from toml
 from AFQ.definitions.utils import Definition
-import nibabel as nib  # interprets nibabel images for endpoint_info
+
+import nibabel as nib  # allows users to input nibabel objects
 
 
 def parse_string(option, opt, value, parser):
@@ -165,7 +165,10 @@ def func_dict_to_arg_dict(func_dict=None, logger=None):
         for arg, info in docstr_parser.unfinished_arguments.items():
             try:
                 if name == "AFQ":
-                    if '_params' in arg:
+                    if arg in [
+                            "tracking_params",
+                            "segmentation_params",
+                            "clean_params"]:
                         continue
                     section, desc = info['help'].split('[')[1].split(']')
                 else:
@@ -222,6 +225,8 @@ def parse_config_run_afq(toml_file, default_arg_dict, to_call="export_all",
                 default_arg_dict[section] = {}
             if arg == 'bids_path':
                 bids_path = default
+            elif section == "KWARGS":
+                kwargs[arg] = toml_to_val(default)
             elif arg in default_arg_dict[section]:
                 val = toml_to_val(default)
                 is_special = False
@@ -243,7 +248,7 @@ def parse_config_run_afq(toml_file, default_arg_dict, to_call="export_all",
     # if overwrite, write new file with updated docs / args
     if overwrite:
         if logger is not None:
-            logger.info(f"Updating configuration file.")
+            logger.info("Updating configuration file.")
         with open(toml_file, 'w') as ff:
             ff.write(dict_to_toml(default_arg_dict))
 


### PR DESCRIPTION
This PR has three small changes:

1. Fixes a bug where in one part of the code, we assumed arguments ending in `_params` were special (the new `parallel_params` was being treated like `segmentation_params`, `tracking_params`, `clean_params`)
2. Allows **kwargs to have its own section in the config file ([KWARGS]) 
3. Minor flake8 changes