### PR TITLE
[ENH] Replicating mAFQ visualizations using our rendering framework

### DIFF
--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -71,7 +71,7 @@ def viz_bundles(subses_dict,
 
     figure = make_subplots(
         rows=1, cols=2,
-        specs=[[{"type": "scene"}, {"type": "xy"}]])
+        specs=[[{"type": "scene"}, {"type": "scene"}]])
 
     figure = viz_backend.visualize_volume(
         volume,
@@ -275,7 +275,29 @@ def viz_indivBundle(subses_dict,
                         tracking_params=tracking_params,
                         segmentation_params=segmentation_params))
                 fname = op.join(core_dir, fname[1])
-                viz_backend.single_bundle_viz(
+                core_fig = make_subplots(
+                    rows=1, cols=2,
+                    specs=[[{"type": "scene"}, {"type": "scene"}]])
+                core_fig = viz_backend.visualize_volume(
+                    volume,
+                    opacity=volume_opacity_indiv,
+                    flip_axes=flip_axes,
+                    figure=core_fig,
+                    interact=False,
+                    inline=False)
+                core_fig = viz_backend.visualize_bundles(
+                    segmentation_imap["clean_bundles_file"],
+                    color_by_volume=color_by_volume,
+                    cbv_lims=cbv_lims_indiv,
+                    bundle_dict=bundle_dict,
+                    bundle=uid,
+                    colors={bundle_name: [0.5, 0.5, 0.5]},
+                    n_points=n_points_indiv,
+                    flip_axes=flip_axes,
+                    interact=False,
+                    inline=False,
+                    figure=core_fig)
+                core_fig = viz_backend.single_bundle_viz(
                     indiv_profile,
                     segmentation_imap["clean_bundles_file"],
                     uid,
@@ -283,7 +305,9 @@ def viz_indivBundle(subses_dict,
                     affine=None,
                     bundle_dict=bundle_dict,
                     flip_axes=flip_axes,
-                    include_profile=True).write_html(fname)
+                    figure=core_fig,
+                    include_profile=True)
+                core_fig.write_html(fname)
     meta_fname = get_fname(
         subses_dict, '_vizIndiv.json',
         tracking_params=tracking_params,

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -4,6 +4,7 @@ import numpy as np
 import os
 import os.path as op
 from time import time
+import pandas as pd
 
 import pimms
 
@@ -54,6 +55,7 @@ def viz_bundles(subses_dict,
                 n_points=40):
     mapping = mapping_imap["mapping"]
     scalar_dict = segmentation_imap["scalar_dict"]
+    profiles_file = segmentation_imap["profiles_file"]
     volume = data_imap["b0_file"]
     color_by_volume = data_imap[best_scalar + "_file"]
     start_time = time()
@@ -72,16 +74,27 @@ def viz_bundles(subses_dict,
         interact=False,
         inline=False)
 
-    figure = viz_backend.visualize_bundles(
+    figure, shaded_profiles_figure = viz_backend.visualize_bundles(
         segmentation_imap["clean_bundles_file"],
         color_by_volume=color_by_volume,
         cbv_lims=cbv_lims,
         bundle_dict=bundle_dict,
+        include_profiles=(pd.read_csv(profiles_file), best_scalar),
         n_points=n_points,
         flip_axes=flip_axes,
         interact=False,
         inline=False,
         figure=figure)
+
+    shaded_profiles_fname = get_fname(
+        subses_dict, '_shaded_profiles.svg',
+        tracking_params=tracking_params,
+        segmentation_params=segmentation_params)
+
+    shaded_profiles_figure.savefig(
+        shaded_profiles_fname,
+        format='svg',
+        dpi=300)
 
     if "no_gif" not in viz_backend.backend:
         fname = get_fname(

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -87,14 +87,12 @@ def viz_bundles(subses_dict,
         figure=figure)
 
     shaded_profiles_fname = get_fname(
-        subses_dict, '_shaded_profiles.svg',
+        subses_dict, '_shaded_profiles.html',
         tracking_params=tracking_params,
         segmentation_params=segmentation_params)
 
-    shaded_profiles_figure.savefig(
-        shaded_profiles_fname,
-        format='svg',
-        dpi=300)
+    shaded_profiles_figure.write_html(
+        shaded_profiles_fname)
 
     if "no_gif" not in viz_backend.backend:
         fname = get_fname(

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -137,6 +137,7 @@ def viz_indivBundle(subses_dict,
     scalar_dict = segmentation_imap["scalar_dict"]
     volume = data_imap["b0_file"]
     color_by_volume = data_imap[best_scalar + "_file"]
+    profiles = pd.read_csv(segmentation_imap["profiles_file"])
 
     start_time = time()
     volume = _viz_prepare_vol(
@@ -259,6 +260,30 @@ def viz_indivBundle(subses_dict,
             fname = op.join(roi_dir, fname[1])
             figure.write_html(fname)
             fnames.append(fname)
+
+            # also do the core visualizations when using the plotly backend
+            core_dir = op.join(subses_dict['results_dir'], 'viz_core_bundles')
+            os.makedirs(core_dir, exist_ok=True)
+            indiv_profile = profiles[
+                profiles.tractID == bundle_name][best_scalar].to_numpy()
+            if len(indiv_profile) > 1:
+                fname = op.split(
+                    get_fname(
+                        subses_dict,
+                        f'_{bundle_name}'
+                        f'_viz.html',
+                        tracking_params=tracking_params,
+                        segmentation_params=segmentation_params))
+                fname = op.join(core_dir, fname[1])
+                viz_backend.single_bundle_viz(
+                    indiv_profile,
+                    segmentation_imap["clean_bundles_file"],
+                    uid,
+                    best_scalar,
+                    affine=None,
+                    bundle_dict=bundle_dict,
+                    flip_axes=flip_axes,
+                    include_profile=True).write_html(fname)
     meta_fname = get_fname(
         subses_dict, '_vizIndiv.json',
         tracking_params=tracking_params,

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -51,19 +51,19 @@ def viz_bundles(subses_dict,
                 segmentation_params,
                 best_scalar,
                 xform_volume=False,
-                cbv_lims=[None, None],
-                xform_color_by_volume=False,
+                sbv_lims=[None, None],
+                xform_shade_by_volume=False,
                 volume_opacity=0.3,
                 n_points=40):
     mapping = mapping_imap["mapping"]
     scalar_dict = segmentation_imap["scalar_dict"]
     profiles_file = segmentation_imap["profiles_file"]
     volume = data_imap["b0_file"]
-    color_by_volume = data_imap[best_scalar + "_file"]
+    shade_by_volume = data_imap[best_scalar + "_file"]
     start_time = time()
     volume = _viz_prepare_vol(volume, xform_volume, mapping, scalar_dict)
-    color_by_volume = _viz_prepare_vol(
-        color_by_volume, xform_color_by_volume, mapping, scalar_dict)
+    shade_by_volume = _viz_prepare_vol(
+        shade_by_volume, xform_shade_by_volume, mapping, scalar_dict)
 
     flip_axes = [False, False, False]
     for i in range(3):
@@ -83,8 +83,8 @@ def viz_bundles(subses_dict,
 
     figure = viz_backend.visualize_bundles(
         segmentation_imap["clean_bundles_file"],
-        color_by_volume=color_by_volume,
-        cbv_lims=cbv_lims,
+        shade_by_volume=shade_by_volume,
+        sbv_lims=sbv_lims,
         bundle_dict=bundle_dict,
         include_profiles=(pd.read_csv(profiles_file), best_scalar),
         n_points=n_points,
@@ -129,21 +129,21 @@ def viz_indivBundle(subses_dict,
                     reg_template,
                     best_scalar,
                     xform_volume_indiv=False,
-                    cbv_lims_indiv=[None, None],
-                    xform_color_by_volume_indiv=False,
+                    sbv_lims_indiv=[None, None],
+                    xform_shade_by_volume_indiv=False,
                     volume_opacity_indiv=0.3,
                     n_points_indiv=40):
     mapping = mapping_imap["mapping"]
     scalar_dict = segmentation_imap["scalar_dict"]
     volume = data_imap["b0_file"]
-    color_by_volume = data_imap[best_scalar + "_file"]
+    shade_by_volume = data_imap[best_scalar + "_file"]
     profiles = pd.read_csv(segmentation_imap["profiles_file"])
 
     start_time = time()
     volume = _viz_prepare_vol(
         volume, xform_volume_indiv, mapping, scalar_dict)
-    color_by_volume = _viz_prepare_vol(
-        color_by_volume, xform_color_by_volume_indiv, mapping, scalar_dict)
+    shade_by_volume = _viz_prepare_vol(
+        shade_by_volume, xform_shade_by_volume_indiv, mapping, scalar_dict)
 
     flip_axes = [False, False, False]
     for i in range(3):
@@ -163,8 +163,8 @@ def viz_indivBundle(subses_dict,
         try:
             figure = viz_backend.visualize_bundles(
                 segmentation_imap["clean_bundles_file"],
-                color_by_volume=color_by_volume,
-                cbv_lims=cbv_lims_indiv,
+                shade_by_volume=shade_by_volume,
+                sbv_lims=sbv_lims_indiv,
                 bundle_dict=bundle_dict,
                 bundle=uid,
                 n_points=n_points_indiv,
@@ -287,8 +287,8 @@ def viz_indivBundle(subses_dict,
                     inline=False)
                 core_fig = viz_backend.visualize_bundles(
                     segmentation_imap["clean_bundles_file"],
-                    color_by_volume=color_by_volume,
-                    cbv_lims=cbv_lims_indiv,
+                    shade_by_volume=shade_by_volume,
+                    sbv_lims=sbv_lims_indiv,
                     bundle_dict=bundle_dict,
                     bundle=uid,
                     colors={bundle_name: [0.5, 0.5, 0.5]},

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -15,6 +15,8 @@ import AFQ.utils.volume as auv
 import AFQ.data as afd
 from AFQ.viz.utils import visualize_tract_profiles
 
+from plotly.subplots import make_subplots
+
 logger = logging.getLogger('AFQ.api.viz')
 
 
@@ -67,14 +69,19 @@ def viz_bundles(subses_dict,
     for i in range(3):
         flip_axes[i] = (dwi_affine[i, i] < 0)
 
+    figure = make_subplots(
+        rows=1, cols=2,
+        specs=[[{"type": "scene"}, {"type": "xy"}]])
+
     figure = viz_backend.visualize_volume(
         volume,
         opacity=volume_opacity,
         flip_axes=flip_axes,
         interact=False,
-        inline=False)
+        inline=False,
+        figure=figure)
 
-    figure, shaded_profiles_figure = viz_backend.visualize_bundles(
+    figure = viz_backend.visualize_bundles(
         segmentation_imap["clean_bundles_file"],
         color_by_volume=color_by_volume,
         cbv_lims=cbv_lims,
@@ -85,14 +92,6 @@ def viz_bundles(subses_dict,
         interact=False,
         inline=False,
         figure=figure)
-
-    shaded_profiles_fname = get_fname(
-        subses_dict, '_shaded_profiles.html',
-        tracking_params=tracking_params,
-        segmentation_params=segmentation_params)
-
-    shaded_profiles_figure.write_html(
-        shaded_profiles_fname)
 
     if "no_gif" not in viz_backend.backend:
         fname = get_fname(

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -37,10 +37,14 @@ def _inline_interact(scene, inline, interact):
 
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
                       bundle=None, colors=None, shade_by_volume=None,
-                      sbv_lims=[None, None], figure=None, background=(1, 1, 1),
-                      interact=False, inline=False, flip_axes=None):
+                      color_by_streamline=None,
+                      sbv_lims=[None, None], include_profiles=(None, None),
+                      flip_axes=[False, False, False], opacity=1.0,
+                      figure=None, background=(1, 1, 1), interact=False,
+                      inline=False):
     """
-    Visualize bundles in 3D using VTK
+    Visualize bundles in 3D using VTK.
+    Parameters not described below are extras to conform fury and plotly APIs.
 
     Parameters
     ----------
@@ -102,10 +106,7 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
 
     inline : bool
         Whether to embed the visualization inline in a notebook. Only works
-        in the notebook context. Default: False.
-
-    flip_axes : None
-        This parameter is to conform fury and plotly APIs.
+        in the notebook context. Default: False.        
 
     Returns
     -------

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -36,8 +36,8 @@ def _inline_interact(scene, inline, interact):
 
 
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
-                      bundle=None, colors=None, color_by_volume=None,
-                      cbv_lims=[None, None], figure=None, background=(1, 1, 1),
+                      bundle=None, colors=None, shade_by_volume=None,
+                      sbv_lims=[None, None], figure=None, background=(1, 1, 1),
                       interact=False, inline=False, flip_axes=None):
     """
     Visualize bundles in 3D using VTK
@@ -75,17 +75,17 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
         with Tableau 20 RGB values if bundle_dict is None, or dict from
         bundles to Tableau 20 RGB values if bundle_dict is not None.
 
-    color_by_volume : ndarray or str, optional
+    shade_by_volume : ndarray or str, optional
         3d volume use to shade the bundles. If None, no shading
         is performed. Only works when using the plotly backend.
         Default: None
 
-    cbv_lims : ndarray
+    sbv_lims : ndarray
         Of the form (lower bound, upper bound). Shading based on
-        color_by_volume will only differentiate values within these bounds.
+        shade_by_volume will only differentiate values within these bounds.
         If lower bound is None, will default to 0.
         If upper bound is None, will default to the maximum value in
-        color_by_volume.
+        shade_by_volume.
         Default: [None, None]
 
     background : tuple, optional

--- a/AFQ/viz/fury_backend.py
+++ b/AFQ/viz/fury_backend.py
@@ -1,5 +1,4 @@
 import tempfile
-import os
 import os.path as op
 import logging
 
@@ -106,7 +105,7 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
 
     inline : bool
         Whether to embed the visualization inline in a notebook. Only works
-        in the notebook context. Default: False.        
+        in the notebook context. Default: False.
 
     Returns
     -------

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -500,7 +500,8 @@ def _draw_slice(figure, axis, volume, opacity=0.3, step=None, n_steps=0):
             opacity=opacity,
             visible=visible,
             name=_name_from_enum(axis),
-            hoverinfo='skip'
+            hoverinfo='skip',
+            showlegend=True
         ),
         row=1, col=1
     )

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -80,7 +80,6 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
                       sbv_lims=[None, None], flip_axes=[False, False, False],
                       opacity=1.0):
     color = np.asarray(color)
-    cbs = np.asarray(cbs)
 
     if len(sls._offsets) > 1:
         plotting_shape = (sls._data.shape[0] + sls._offsets.shape[0])
@@ -92,6 +91,7 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
     z_pts = np.zeros(plotting_shape)
 
     if cbs is not None:
+        cbs = np.asarray(cbs)
         color = cbs[0, :]
     elif cbv is not None:
         if sbv_lims[0] is None:

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -498,7 +498,7 @@ class Axes(enum.IntEnum):
 
 
 def _draw_slice(figure, axis, volume, opacity=0.3, pos=0.5,
-                colorscale="greys"):
+                colorscale="greys", invert_colorscale=False):
     height = int(volume.shape[axis] * pos)
 
     v_min = volume.min()
@@ -517,7 +517,9 @@ def _draw_slice(figure, axis, volume, opacity=0.3, pos=0.5,
                            :volume.shape[1], height:height + 1]
         values = volume[:, :, height].flatten()
 
-    values = 1 - (values - v_min) / sf
+    values = (values - v_min) / sf
+    if invert_colorscale:
+        values = 1 - values
 
     figure.add_trace(
         go.Volume(
@@ -548,7 +550,7 @@ def _name_from_enum(axis):
 
 def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
                      z_pos=0.5, interact=False, inline=False, opacity=0.3,
-                     colorscale="greys",
+                     colorscale="gray", invert_colorscale=False,
                      flip_axes=[False, False, False]):
     """
     Visualize a volume
@@ -591,6 +593,10 @@ def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
         Plotly colorscale to use to color slices.
         Default: "greys"
 
+    invert_colorscale : bool, optional
+        Whether to invert colorscale.
+        Default: False
+
     flip_axes : ndarray
         Which axes to flip, to orient the image as RAS, which is how we
         visualize.
@@ -625,7 +631,8 @@ def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
         if pos is not None:
             _draw_slice(
                 figure, axis, volume, opacity=opacity,
-                pos=pos, colorscale=colorscale)
+                pos=pos, colorscale=colorscale,
+                invert_colorscale=invert_colorscale)
 
     return _inline_interact(figure, interact, inline)
 

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -497,7 +497,8 @@ class Axes(enum.IntEnum):
     Z = 2
 
 
-def _draw_slice(figure, axis, volume, opacity=0.3, pos=0.5):
+def _draw_slice(figure, axis, volume, opacity=0.3, pos=0.5,
+                colorscale="greys"):
     height = int(volume.shape[axis] * pos)
 
     v_min = volume.min()
@@ -524,7 +525,7 @@ def _draw_slice(figure, axis, volume, opacity=0.3, pos=0.5):
             y=Y.flatten(),
             z=Z.flatten(),
             value=values,
-            colorscale='greys',
+            colorscale=colorscale,
             surface_count=1,
             showscale=False,
             opacity=opacity,
@@ -547,6 +548,7 @@ def _name_from_enum(axis):
 
 def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
                      z_pos=0.5, interact=False, inline=False, opacity=0.3,
+                     colorscale="greys",
                      flip_axes=[False, False, False]):
     """
     Visualize a volume
@@ -565,25 +567,29 @@ def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
         Should be a decimal between 0 and 1.
         Indicatesthe fractional position along the perpendicular
         axis to the slice.
-        Default: True
+        Default: 0.5
 
     y_pos : float or None, optional
         Where to show Sagittal Slice. If None, slice is not shown.
         Should be a decimal between 0 and 1.
         Indicatesthe fractional position along the perpendicular
         axis to the slice.
-        Default: True
+        Default: 0.5
 
     z_pos : float or None, optional
         Where to show Axial Slice. If None, slice is not shown.
         Should be a decimal between 0 and 1.
         Indicatesthe fractional position along the perpendicular
         axis to the slice.
-        Default: True
+        Default: 0.5
 
     opacity : float, optional
         Opacity of slices.
         Default: 1.0
+
+    colorscale : string, optional
+        Plotly colorscale to use to color slices.
+        Default: "greys"
 
     flip_axes : ndarray
         Which axes to flip, to orient the image as RAS, which is how we
@@ -615,13 +621,11 @@ def visualize_volume(volume, figure=None, x_pos=0.5, y_pos=0.5,
 
     set_layout(figure)
 
-    # draw stationary slices first
-    if x_pos is not None:
-        _draw_slice(figure, Axes.X, volume, opacity=opacity, pos=x_pos)
-    if y_pos is not None:
-        _draw_slice(figure, Axes.Y, volume, opacity=opacity, pos=y_pos)
-    if z_pos is not None:
-        _draw_slice(figure, Axes.Z, volume, opacity=opacity, pos=z_pos)
+    for pos, axis in [(x_pos, Axes.X), (y_pos, Axes.Y), (z_pos, Axes.Z)]:
+        if pos is not None:
+            _draw_slice(
+                figure, axis, volume, opacity=opacity,
+                pos=pos, colorscale=colorscale)
 
     return _inline_interact(figure, interact, inline)
 

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -18,7 +18,6 @@ try:
     import plotly.graph_objs as go
     import plotly.io as pio
     from plotly.subplots import make_subplots
-    from plotly.tools import mpl_to_plotly
 except ImportError:
     raise ImportError(vut.viz_import_msg_error("plotly"))
 
@@ -79,7 +78,8 @@ def set_layout(figure, color=None):
 
 
 def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None,
-                      cbv_lims=[None, None], flip_axes=[False, False, False]):
+                      cbv_lims=[None, None], flip_axes=[False, False, False],
+                      opacity=1.0):
     color = np.asarray(color)
 
     if len(sls._offsets) > 1:
@@ -163,7 +163,8 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None,
                 color=line_color,
             ),
             hovertext=customdata,
-            hoverinfo='all'
+            hoverinfo='all',
+            opacity=opacity
         ),
         row=1, col=1
     )
@@ -215,7 +216,7 @@ def _plot_profiles(profiles, bundle_name, color, fig, scalar):
 def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
                       bundle=None, colors=None, color_by_volume=None,
                       cbv_lims=[None, None], include_profiles=(None, None),
-                      flip_axes=[False, False, False],
+                      flip_axes=[False, False, False], opacity=1.0,
                       figure=None, background=(1, 1, 1), interact=False,
                       inline=False):
     """
@@ -283,6 +284,10 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
         For example, if the input image is LAS, use [True, False, False].
         Default: [False, False, False]
 
+    opacity : float
+        Float between 0 and 1 defining the opacity of the bundle.
+        Default: 1.0
+
     background : tuple, optional
         RGB values for the background. Default: (1, 1, 1), which is white
         background.
@@ -329,7 +334,8 @@ def visualize_bundles(sft, affine=None, n_points=None, bundle_dict=None,
             name,
             cbv=color_by_volume,
             cbv_lims=cbv_lims,
-            flip_axes=flip_axes)
+            flip_axes=flip_axes,
+            opacity=opacity)
         if include_profiles[0] is not None:
             _plot_profiles(
                 include_profiles[0], name, color_constant,

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -92,6 +92,7 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
 
     if cbs is not None:
         cbs = np.asarray(cbs)
+        line_color = np.zeros((plotting_shape, cbs.shape[1]))
         color = cbs[0, :]
     elif cbv is not None:
         if sbv_lims[0] is None:
@@ -101,10 +102,11 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
 
         color_constant = (color / color.max())\
             * (1.4 / (sbv_lims[1] - sbv_lims[0])) + sbv_lims[0]
+        line_color = np.zeros((plotting_shape, 3))
     else:
         color_constant = color
+        line_color = np.zeros((plotting_shape, 3))
     customdata = np.zeros(plotting_shape)
-    line_color = np.zeros((plotting_shape, 3))
 
     for sl_index, plotting_offset in enumerate(sls._offsets):
         sl_length = sls._lengths[sl_index]
@@ -141,7 +143,7 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
             customdata[total_offset:total_offset + sl_length] = 1
 
             if len(sls._offsets) > 1:
-                line_color[total_offset + sl_length, :] = [0, 0, 0]
+                line_color[total_offset + sl_length, :] = 0
                 customdata[total_offset + sl_length] = 0
 
     if flip_axes[0]:

--- a/AFQ/viz/plotly_backend.py
+++ b/AFQ/viz/plotly_backend.py
@@ -142,9 +142,13 @@ def _draw_streamlines(figure, sls, dimensions, color, name, cbv=None, cbs=None,
                 color_constant
             customdata[total_offset:total_offset + sl_length] = 1
 
-            if len(sls._offsets) > 1:
-                line_color[total_offset + sl_length, :] = 0
-                customdata[total_offset + sl_length] = 0
+        if line_color.shape[1] > 3:
+            line_color[total_offset:total_offset + sl_length, 3] = \
+                color_constant[3]  # dont shade alpha values
+
+        if len(sls._offsets) > 1:
+            line_color[total_offset + sl_length, :] = 0
+            customdata[total_offset + sl_length] = 0
 
     if flip_axes[0]:
         x_pts = dimensions[0] - x_pts

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -604,7 +604,7 @@ class BrainAxes():
             sns.lineplot(
                 x=x, y=y,
                 data=data,
-                ci=None, estimator=None,
+                ci=None, estimator=None, units='subjectID',
                 legend=False, ax=ax, alpha=alpha - 0.2,
                 style=[True] * len(data.index), **lineplot_kwargs)
 
@@ -1077,13 +1077,11 @@ class GroupCSVComparison():
                 if i == 0:
                     plot_kwargs = {
                         "hue": "tractID",
-                        "units": 'subjectID',
                         "palette": [self.color_dict[bundle]]}
                 else:
                     plot_kwargs = {
                         "dashes": [(2**(i - 1), 2**(i - 1))],
                         "hue": "tractID",
-                        "units": 'subjectID',
                         "palette": [self.color_dict[bundle]]}
                 profile = self.profile_dict[name]
                 profile = profile[profile['tractID'] == bundle]
@@ -1206,9 +1204,7 @@ class GroupCSVComparison():
                 [bundle], names, scalar)
             ba.plot_line(
                 bundle, "nodeID", "diff", ci_df, "ACI", ylim,
-                n_boot, 1.0, {
-                    "color": self.color_dict[bundle],
-                    "units": 'subjectID'},
+                n_boot, 1.0, {"color": self.color_dict[bundle]},
                 plot_subject_lines=plot_subject_lines,
                 ax=axes_dict.get(bundle))
             ci_all_df[bundle] = ci_df
@@ -1286,9 +1282,7 @@ class GroupCSVComparison():
                 [bundle, other_bundle], [name], scalar)
             ba.plot_line(
                 bundle, "nodeID", "diff", ci_df, "ACI", ylim,
-                n_boot, 1.0, {
-                    "color": self.color_dict[bundle],
-                    "units": 'subjectID'},
+                n_boot, 1.0, {"color": self.color_dict[bundle]},
                 plot_subject_lines=plot_subject_lines)
             ba.save_temp_fig(
                 f"contrast_plots/{scalar}/",

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -124,7 +124,7 @@ def viz_import_msg_error(module):
     """Alerts user to install the appropriate viz module """
     msg = f"To use {module.upper()} visualizations in pyAFQ, you will need "
     msg += f"to have {module.upper()} installed. "
-    msg += f"You can do that by installing pyAFQ with "
+    msg += "You can do that by installing pyAFQ with "
     msg += f"`pip install AFQ[{module.lower()}]`, or by "
     msg += f"separately installing {module.upper()}: "
     msg += f"`pip install {module.lower()}`."
@@ -604,7 +604,7 @@ class BrainAxes():
             sns.lineplot(
                 x=x, y=y,
                 data=data,
-                ci=None, estimator=None, units='subjectID',
+                ci=None, estimator=None,
                 legend=False, ax=ax, alpha=alpha - 0.2,
                 style=[True] * len(data.index), **lineplot_kwargs)
 
@@ -990,16 +990,16 @@ class GroupCSVComparison():
                 raters="raters",
                 ratings="ratings")
             row = stats[stats["Type"] == self.ICC_func].iloc[0]
-            return row["ICC"], row["ICC"]-row["CI95%"][0],\
-                row["CI95%"][1]-row["ICC"]
+            return row["ICC"], row["ICC"] - row["CI95%"][0],\
+                row["CI95%"][1] - row["ICC"]
         elif corrtype == "Srho":
             stats = corr(
                 x=arr[0],
                 y=arr[1],
                 method="spearman")
             row = stats.iloc[0]
-            return row["r"], row["r"]-row["CI95%"][0],\
-                row["CI95%"][1]-row["r"]
+            return row["r"], row["r"] - row["CI95%"][0],\
+                row["CI95%"][1] - row["r"]
         else:
             raise ValueError("corrtype not recognized")
 
@@ -1077,11 +1077,13 @@ class GroupCSVComparison():
                 if i == 0:
                     plot_kwargs = {
                         "hue": "tractID",
+                        "units": 'subjectID',
                         "palette": [self.color_dict[bundle]]}
                 else:
                     plot_kwargs = {
                         "dashes": [(2**(i - 1), 2**(i - 1))],
                         "hue": "tractID",
+                        "units": 'subjectID',
                         "palette": [self.color_dict[bundle]]}
                 profile = self.profile_dict[name]
                 profile = profile[profile['tractID'] == bundle]
@@ -1204,7 +1206,9 @@ class GroupCSVComparison():
                 [bundle], names, scalar)
             ba.plot_line(
                 bundle, "nodeID", "diff", ci_df, "ACI", ylim,
-                n_boot, 1.0, {"color": self.color_dict[bundle]},
+                n_boot, 1.0, {
+                    "color": self.color_dict[bundle],
+                    "units": 'subjectID'},
                 plot_subject_lines=plot_subject_lines,
                 ax=axes_dict.get(bundle))
             ci_all_df[bundle] = ci_df
@@ -1282,7 +1286,9 @@ class GroupCSVComparison():
                 [bundle, other_bundle], [name], scalar)
             ba.plot_line(
                 bundle, "nodeID", "diff", ci_df, "ACI", ylim,
-                n_boot, 1.0, {"color": self.color_dict[bundle]},
+                n_boot, 1.0, {
+                    "color": self.color_dict[bundle],
+                    "units": 'subjectID'},
                 plot_subject_lines=plot_subject_lines)
             ba.save_temp_fig(
                 f"contrast_plots/{scalar}/",
@@ -1422,7 +1428,7 @@ class GroupCSVComparison():
                 all_sub_means[m, k] = np.nanmean(bundle_profiles, axis=2)
                 all_sub_coef[m, k], all_sub_coef_err[m, k, 0],\
                     all_sub_coef_err[m, k, 1] =\
-                        self.masked_corr(all_sub_means[m, k], "Srho")
+                    self.masked_corr(all_sub_means[m, k], "Srho")
                 if np.isnan(all_sub_coef[m, k]).all():
                     self.logger.error((
                         f"Not enough non-nan profiles"
@@ -1607,7 +1613,7 @@ class GroupCSVComparison():
                         marker=self.scalar_markers[0],
                         linewidth=0,
                         markersize=15)]
-                leg = ba.fig.legend(
+                ba.fig.legend(
                     legend_labels,
                     display_string(scalars),
                     loc='center',

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -459,6 +459,7 @@ class Viz:
             self.visualize_roi = AFQ.viz.plotly_backend.visualize_roi
             self.visualize_volume = AFQ.viz.plotly_backend.visualize_volume
             self.create_gif = AFQ.viz.plotly_backend.create_gif
+            self.single_bundle_viz = AFQ.viz.plotly_backend.single_bundle_viz
         else:
             raise TypeError("Visualization backend contain"
                             + " either 'plotly' or 'fury'. "

--- a/examples/plot_callosal_tract_profile.py
+++ b/examples/plot_callosal_tract_profile.py
@@ -457,7 +457,7 @@ for bundle in bundles:
 
 plotly.io.show(visualize_bundles(tractogram,
                                  figure=visualize_volume(warped_MNI_T2_data),
-                                 color_by_volume=FA_data))
+                                 shade_by_volume=FA_data))
 
 ##########################################################################
 # Bundle profiles:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,10 @@ install_requires =
     funcargparse==0.2.*
     packaging>=19.0.0,<21.0.0
     seaborn==0.11.*
-    plotly==4.9.0
+    plotly==5.3.0
     pingouin>=0.3
     psutil>=5.7.0,<5.9.0
-    kaleido==0.0.3.post1
+    kaleido==0.2.1
     pip-conflict-checker==0.6.*
     ipython>=7.13.0,<=7.20.0
     pimms


### PR DESCRIPTION
A user found these plots to be particularly helpful:
![image](https://user-images.githubusercontent.com/9562159/129270025-47139def-f589-462d-a48a-21221afb0ebc.png)

So I am trying to replicate these plots within our existing visualization framework. 
I am breaking this down into steps:

- [x] Show tract profiles with shading that is the same as the corresponding plotly visualization
- [x] Merge these into one picture
- [x] Add the 0, 50, and 100 marks to the plotly visualizations
- [x] Add the core streamline 3d visualization and not-core profiles
- [x] Color by streamline