### PR TITLE
[WIP] draft of converting QSIprep params to kwargs for API object

### DIFF
--- a/AFQ/utils/bin.py
+++ b/AFQ/utils/bin.py
@@ -235,35 +235,6 @@ def func_dict_to_arg_dict(func_dict=None, logger=None):
     return arg_dict
 
 
-def parse_qsiprep_params_dict(params_dict):
-    arg_dict = func_dict_to_arg_dict()
-    kwargs = {}
-
-    special_args = {
-        "CLEANING": "clean_params",
-        "SEGMENTATION": "segmentation_params",
-        "TRACTOGRAPHY": "tracking_params"}
-
-    for section, args in arg_dict.items():
-        if section == "AFQ_desc":
-            continue
-        for arg, arg_info in args.items():
-            if arg in special_args.keys():
-                kwargs[special_args[arg]] = {}
-                for actual_arg in arg_info.keys():
-                    if actual_arg in params_dict:
-                        kwargs[special_args[arg]][actual_arg] = toml_to_val(
-                            params_dict[actual_arg])
-            else:
-                if arg in params_dict:
-                    kwargs[arg] = toml_to_val(params_dict[arg])
-
-    for ignore_param in qsi_prep_ignore_params:
-        kwargs.pop(ignore_param, None)
-
-    return kwargs
-
-
 def parse_config_run_afq(toml_file, default_arg_dict, to_call="export_all",
                          overwrite=False,
                          logger=None,

--- a/AFQ/utils/bin.py
+++ b/AFQ/utils/bin.py
@@ -227,6 +227,27 @@ def func_dict_to_arg_dict(func_dict=None, logger=None):
     return arg_dict
 
 
+def parse_qsiprep_params_dict(params_dict):
+    arg_dict = func_dict_to_arg_dict()
+    kwargs = {}
+
+    special_args = {
+        "CLEANING": "clean_params",
+        "SEGMENTATION": "segmentation_params",
+        "TRACTOGRAPHY": "tracking_params"}
+
+    for section, arg_name in special_args.items():
+        kwargs[arg_name] = {}
+        for key in arg_dict[section].keys():
+            if key in params_dict:
+                kwargs[arg_name][key] = toml_to_val(params_dict[key])
+
+    for arg, val in params_dict.items():
+        kwargs[arg] = toml_to_val(val)
+
+    return kwargs
+
+
 def parse_config_run_afq(toml_file, default_arg_dict, to_call="export_all",
                          overwrite=False,
                          logger=None,


### PR DESCRIPTION
As far as I understand, QSIprep will extract params from the json file (we have made a default one) and put them in a dictionary. This converts the extracted dictionary into kwargs that can be passed directly into AFQ.api. Two things in particular must be done: pass args through toml_to_val, which converts some strings into objects or dicts if necessary; organize relevant arguments into segmentation_params / clean_params / tractography params. 