### PR TITLE
[FIX] this is a quick fix for the problem with using the default config file

### DIFF
--- a/AFQ/api.py
+++ b/AFQ/api.py
@@ -804,12 +804,6 @@ class AFQ(object):
 
         best_scalar = self._get_best_scalar()
         default_tracking_params = get_default_args(aft.track)
-        default_tracking_params["seed_mask"] = ScalarMask(
-            best_scalar)
-        default_tracking_params["stop_mask"] = ScalarMask(
-            best_scalar)
-        default_tracking_params["seed_threshold"] = 0.2
-        default_tracking_params["stop_threshold"] = 0.2
         # Replace the defaults only for kwargs for which a non-default value
         # was given:
         if tracking_params is not None:
@@ -819,6 +813,14 @@ class AFQ(object):
         self.tracking_params = default_tracking_params
         self.tracking_params["odf_model"] =\
             self.tracking_params["odf_model"].upper()
+        if self.tracking_params["seed_mask"] is None:
+            self.tracking_params["seed_mask"] = ScalarMask(
+                best_scalar)
+            self.tracking_params["seed_threshold"] = 0.2
+        if self.tracking_params["stop_mask"] is None:
+            self.tracking_params["stop_mask"] = ScalarMask(
+                best_scalar)
+            self.tracking_params["stop_threshold"] = 0.2
 
         default_seg_params = get_default_args(seg.Segmentation.__init__)
         if segmentation_params is not None:

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -554,7 +554,28 @@ def test_AFQ_reco80():
     """
     Test API segmentation with the 80-bundle atlas
     """
-    _, bids_path, _ = get_temp_hardi()
+    tmpdir, bids_path, _ = get_temp_hardi()
+    config_file = op.join(tmpdir.name, "afq_config.toml")
+    completed_process = subprocess.run(
+        f"pyAFQ -g {config_file}",
+        shell=True, capture_output=True)
+    if completed_process.returncode != 0:
+        print(completed_process.stdout)
+    print(completed_process.stderr)
+
+    with open(config_file, 'a') as ff:
+        ff.write((
+            f"\nbids_path = {bids_path}\n"
+            "preproc_pipeline = 'vistasoft'\n"
+            "segmentation_params = \"{'seg_algo': 'reco80', 'rng': 42}\""))
+
+    cmd = "pyAFQ -v -c export_clean_bundles" + config_file
+    completed_process = subprocess.run(
+        cmd, shell=True, capture_output=True)
+    if completed_process.returncode != 0:
+        print(completed_process.stdout)
+    print(completed_process.stderr)
+
     myafq = api.AFQ(
         bids_path=bids_path,
         preproc_pipeline='vistasoft',

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     scikit_image>=0.14.2
     dipy>=1.4.0,<1.5.0
     pandas
-    pybids>=0.9.3
+    pybids>=0.9.3,<0.14.0
     templateflow==0.6.2
     pimms
     joblib>=0.16.0


### PR DESCRIPTION
Fixes #767 and #763 . I think this whole system will be redesigned in #764 anyways. The problem here is that the default config file was being populated with the default params from each function's documentation, but in in the seed mask case, that default is None. We want by default to replace the `None` arguments with proper seed mask definitions in this case. If the user doesn't want to mask, they should use FullMask