### PR TITLE
[ENH] Add entrypoint for pyAFQ docker image

### DIFF
--- a/docs/source/usage/docker.rst
+++ b/docs/source/usage/docker.rst
@@ -1,0 +1,11 @@
+The pyAFQ docker image
+~~~~~~~~~~~~~~~~~~~~~~
+
+Everytime a new commit is made to master the
+`pyAFQ github <https://github.com/yeatmanlab/pyAFQ>`,
+a new image is pushed to the
+`NRDG github <https://github.com/orgs/nrdg/packages/container/package/pyafq>`.
+This image contains an installation latest version of the latest version of
+pyAFQ with fslpy and h5py. This image also contains an entrypoint, and can be
+run with::
+    docker run -v bids_dir:/bids_dir:rw ghcr.io/nrdg/pyafq bids_dir/config.toml

--- a/docs/source/usage/docker.rst
+++ b/docs/source/usage/docker.rst
@@ -5,7 +5,7 @@ Everytime a new commit is made to master the
 `pyAFQ github <https://github.com/yeatmanlab/pyAFQ>`,
 a new image is pushed to the
 `NRDG github <https://github.com/orgs/nrdg/packages/container/package/pyafq>`.
-This image contains an installation latest version of the latest version of
+This image contains an installation of the latest version of
 pyAFQ with fslpy and h5py. This image also contains an entrypoint, and can be
 run with::
     docker run -v bids_dir:/bids_dir:rw ghcr.io/nrdg/pyafq bids_dir/config.toml

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -34,3 +34,4 @@ The csv file has the same format as
     scalars
     converter
     tracking
+    docker

--- a/pyafq_docker/Dockerfile
+++ b/pyafq_docker/Dockerfile
@@ -11,3 +11,5 @@ ARG COMMIT
 RUN pip install --no-cache-dir git+https://github.com/yeatmanlab/pyAFQ.git@${COMMIT}
 RUN pip install fslpy
 RUN pip install h5py
+
+ENTRYPOINT ["pyAFQ"]


### PR DESCRIPTION
This makes the image more useful, for example in working with singularity.
Example usage:
```
docker run -v bids_dir:/bids_dir:rw ghcr.io/nrdg/pyafq bids_dir/config.toml
```