### PR TITLE
[FIX] update cvxpy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ fsl =
 itk =
     h5py
 msmt =
-    cvxpy>=1.1.10,<1.1.12
+    cvxpy>=1.1.15
 afqbrowser =
     AFQ-Browser>=0.3
 plot =


### PR DESCRIPTION
We were forcing an older version of cvxpy, which imported something from scipy which was just deprecated. This PR updates cvxpy.