### PR TITLE
[FIX] fix CLI, % sign in scraped docstring causes error in argparser for CLI

### DIFF
--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -223,7 +223,8 @@ def csd(subses_dict, dwi_affine,
         threshold controlling the amplitude below which the corresponding
         fODF is assumed to be zero.  Ideally, tau should be set to
         zero. However, to improve the stability of the algorithm, tau is
-        set to tau*100 % of the mean fODF amplitude (here, 10% by default)
+        set to tau*100 percent of the mean fODF amplitude (here, 10 percent
+        by default)
         (see [1]_). Default: 0.1
 
     References
@@ -248,7 +249,7 @@ def csd(subses_dict, dwi_affine,
             'Could not compute CSD response function for subject: '
             f'{subses_dict["subject"]} in session: {subses_dict["ses"]} '
             f'file: {subses_dict["dwi_file"]}.'
-            )
+        )
     meta = dict(
         SphericalHarmonicDegree=csd_sh_order,
         ResponseFunctionTensor=csd_response,

--- a/docs/source/developing/tasks.rst
+++ b/docs/source/developing/tasks.rst
@@ -39,7 +39,9 @@ task which the user should input, make them a kwarg with a reasonable default,
 and add a description to the docstring in a properly formatted parameters
 section. Note that when an output is attached to the AFQ class either as
 an attribute or method, if that output name ends in '_file',
-the '_file' is removed from the name automatically. 
+the '_file' is removed from the name automatically. Also, do not use
+the % character in task docstrings, as this will lead to an error in
+parsing the docstring.
 
 Task Decorators
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
This should fix the CLI, however I wonder if this should be documented somewhere