### PR TITLE
[test] Move reco80 from custom to anisotropic nightly test

### DIFF
--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -484,7 +484,7 @@ def test_AFQ_reco():
     myafq.export_all()
 
 
-@pytest.mark.nightly_custom
+@pytest.mark.nightly_anisotropic
 def test_AFQ_reco80():
     """
     Test API segmentation with the 80-bundle atlas


### PR DESCRIPTION
The custom nightly keeps running out of memory. Here I tried to lighten the load on that action. 