### PR TITLE
DOC: Add pointer to discussions page in getting_help.rst

### DIFF
--- a/docs/source/getting_help.rst
+++ b/docs/source/getting_help.rst
@@ -4,7 +4,8 @@ Getting help using pyAFQ
 If you run into any bugs or issues using pyAFQ, please contact us using
 one of the following communication channels:
 
-#. You can post an issue on our GitHub repository by going to this
+#. If you encounter a problem using the code, you can post an issue on our
+   GitHub repository by going to this
    `page <https://github.com/yeatmanlab/pyAFQ/issues>`_ and clicking on the "new
    issue" button. Please provide all pertinent information about the issue you
    are facing: we often need to know what version of the software you are
@@ -13,6 +14,10 @@ one of the following communication channels:
    small sample of your data with us, so that we can examine it. Please make
    sure that your study ethics procedure allows you to share this data before
    sending it on to us.
+
+#. If you would like to start a discussion about future developments or about
+   the method, consider starting a discussion on this
+   `page <https://github.com/yeatmanlab/pyAFQ/discussions>`_
 
 #. Questions regarding the method and its use can also be posted to the
    `Neurostars <https://neurostars.org/>`_ Q&A forum.

--- a/docs/source/getting_help.rst
+++ b/docs/source/getting_help.rst
@@ -17,7 +17,7 @@ one of the following communication channels:
 
 #. If you would like to start a discussion about future developments or about
    the method, consider starting a discussion on this
-   `page <https://github.com/yeatmanlab/pyAFQ/discussions>`_
+   `page <https://github.com/yeatmanlab/pyAFQ/discussions>`_.
 
 #. Questions regarding the method and its use can also be posted to the
    `Neurostars <https://neurostars.org/>`_ Q&A forum.


### PR DESCRIPTION
This is just a small change to the documentation that helps users differentiate between issues and discussions. Maybe we can spark some discussion here!
