### PR TITLE
[FIX] Replace split(.) with splitext()

### DIFF
--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -6,6 +6,7 @@ from dipy.io.streamline import (
     load_tractogram, save_tractogram, StatefulTractogram, Space)
 from dipy.data.fetcher import _make_fetcher
 import dipy.data as dpd
+from AFQ.utils.path import drop_extension
 
 import os
 import os.path as op
@@ -93,7 +94,7 @@ def _fetcher_to_template(fetcher, as_img=False, resample_to=False):
                                            img.affine,
                                            resample_to.affine).get_fdata(),
                                   resample_to.affine)
-        template_dict[op.splitext(f)[0]] = img
+        template_dict[drop_extension(f)] = img
     return template_dict
 
 
@@ -929,8 +930,8 @@ def read_hcp_atlas(n_bundles=16, as_file=False):
         "centroid")
     os.makedirs(centroid_folder, exist_ok=True)
     for bundle_file in bundle_files:
-        bundle = op.splitext(op.split(bundle_file)[-1])[0]
-        centroid_file = op.join(centroid_folder, bundle + ".trk")
+        bundle = drop_extension(op.split(bundle_file)[-1])
+        centroid_file = op.join(centroid_folder, f"{bundle}.trk")
         bundle_dict[bundle] = {}
         if not op.exists(centroid_file):
             bundle_sl = load_tractogram(

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -93,7 +93,7 @@ def _fetcher_to_template(fetcher, as_img=False, resample_to=False):
                                            img.affine,
                                            resample_to.affine).get_fdata(),
                                   resample_to.affine)
-        template_dict[f.split('.')[0]] = img
+        template_dict[op.splitext(f)[0]] = img
     return template_dict
 
 

--- a/AFQ/definitions/utils.py
+++ b/AFQ/definitions/utils.py
@@ -1,5 +1,7 @@
 import os.path as op
 
+from AFQ.utils.path import drop_extension
+
 __all__ = ["Definition", "find_file", "name_from_path"]
 
 
@@ -63,7 +65,7 @@ def _arglist_to_string(args, get_attr=None):
 
 def name_from_path(path):
     file_name = op.basename(path)  # get file name
-    file_name = op.splitext(file_name)[0]  # remove extension
+    file_name = drop_extension(file_name)  # remove extension
     if "-" in file_name:
         file_name = file_name.split("-")[-1]  # get suffix if exists
     return file_name

--- a/AFQ/tasks/decorators.py
+++ b/AFQ/tasks/decorators.py
@@ -104,7 +104,7 @@ def as_file(suffix, include_track=False, include_seg=False):
                 else:
                     img_trk_or_csv.to_csv(this_file)
                 meta_fname = get_fname(
-                    subses_dict, suffix.split('.')[0] + '.json',
+                    subses_dict, op.splitext(suffix)[0] + '.json',
                     tracking_params=tracking_params,
                     segmentation_params=segmentation_params)
                 write_json(meta_fname, meta)

--- a/AFQ/tasks/decorators.py
+++ b/AFQ/tasks/decorators.py
@@ -12,6 +12,7 @@ from AFQ.data.s3bids import write_json
 import numpy as np
 
 from AFQ.tasks.utils import get_fname
+from AFQ.utils.path import drop_extension
 
 
 __all__ = ["as_file", "as_model", "as_dt_deriv", "as_img"]
@@ -104,7 +105,7 @@ def as_file(suffix, include_track=False, include_seg=False):
                 else:
                     img_trk_or_csv.to_csv(this_file)
                 meta_fname = get_fname(
-                    subses_dict, op.splitext(suffix)[0] + '.json',
+                    subses_dict, drop_extension(suffix) + '.json',
                     tracking_params=tracking_params,
                     segmentation_params=segmentation_params)
                 write_json(meta_fname, meta)

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -86,8 +86,8 @@ def export_rois(subses_dict, data_imap, mapping, dwi_affine):
                             nib.Nifti1Image(
                                 warped_roi.astype(np.float32),
                                 dwi_affine), fname)
-                        meta = dict()
-                        meta_fname = fname.split('.')[0] + '.json'
+                        meta = {}
+                        meta_fname = f'{op.splitext(fname)[0]}.json'
                         write_json(meta_fname, meta)
                     roi_files[bundle].append(fname)
     return {'rois_file': roi_files}

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -9,6 +9,7 @@ from AFQ.tasks.decorators import as_file
 from AFQ.tasks.utils import get_fname, with_name
 import AFQ.data.fetch as afd
 from AFQ.data.s3bids import write_json
+from AFQ.utils.path import drop_extension
 import AFQ.utils.volume as auv
 from AFQ.definitions.mapping import SynMap
 from AFQ.definitions.utils import Definition
@@ -87,7 +88,7 @@ def export_rois(subses_dict, data_imap, mapping, dwi_affine):
                                 warped_roi.astype(np.float32),
                                 dwi_affine), fname)
                         meta = {}
-                        meta_fname = f'{op.splitext(fname)[0]}.json'
+                        meta_fname = f'{drop_extension(fname)}.json'
                         write_json(meta_fname, meta)
                     roi_files[bundle].append(fname)
     return {'rois_file': roi_files}

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -11,6 +11,7 @@ import pimms
 from AFQ.tasks.decorators import as_file
 from AFQ.tasks.utils import get_fname, with_name
 import AFQ.segmentation as seg
+from AFQ.utils.path import drop_extension
 import AFQ.utils.streamlines as aus
 from AFQ.tasks.utils import get_default_args
 from AFQ.data.s3bids import write_json
@@ -178,7 +179,7 @@ def export_bundles(subses_dict, clean_bundles_file, bundles_file,
                     seg_sft.get_bundle(bundle), fname,
                     bbox_valid_check=False)
                 meta = dict(source=this_bundles_file)
-                meta_fname = op.splitext(fname)[0] + '.json'
+                meta_fname = drop_extension(fname) + '.json'
                 write_json(meta_fname, meta)
     return True
 

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -178,7 +178,7 @@ def export_bundles(subses_dict, clean_bundles_file, bundles_file,
                     seg_sft.get_bundle(bundle), fname,
                     bbox_valid_check=False)
                 meta = dict(source=this_bundles_file)
-                meta_fname = fname.split('.')[0] + '.json'
+                meta_fname = op.splitext(fname)[0] + '.json'
                 write_json(meta_fname, meta)
     return True
 

--- a/AFQ/utils/path.py
+++ b/AFQ/utils/path.py
@@ -1,4 +1,6 @@
+import os.path as op
+
+
 def drop_extension(path):
-    base_fname = path.split('/')[-1].split('.')[0]
-    path.split(base_fname)[0] + base_fname
-    return path
+    base_fname = op.basename(path).split('.')[0]
+    return path.split(base_fname)[0] + base_fname

--- a/AFQ/utils/path.py
+++ b/AFQ/utils/path.py
@@ -1,0 +1,4 @@
+def drop_extension(path):
+    base_fname = path.split('/')[-1].split('.')[0]
+    path.split(base_fname)[0] + base_fname
+    return path

--- a/AFQ/utils/streamlines.py
+++ b/AFQ/utils/streamlines.py
@@ -60,7 +60,7 @@ class SegmentedSFT():
         if sidecar_file is None:
             # assume json sidecar has the same name as trk_file,
             # but with json suffix
-            sidecar_file = trk_file.split('.')[0] + '.json'
+            sidecar_file = f'{op.splitext(trk_file)[0]}.json'
             if not op.exists(sidecar_file):
                 raise ValueError((
                     "JSON sidecars are required for trk files. "

--- a/AFQ/utils/streamlines.py
+++ b/AFQ/utils/streamlines.py
@@ -5,6 +5,8 @@ from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from AFQ.data.s3bids import read_json
 import os.path as op
 
+from AFQ.utils.path import drop_extension
+
 
 class SegmentedSFT():
     def __init__(self, bundles, space):
@@ -60,7 +62,7 @@ class SegmentedSFT():
         if sidecar_file is None:
             # assume json sidecar has the same name as trk_file,
             # but with json suffix
-            sidecar_file = f'{op.splitext(trk_file)[0]}.json'
+            sidecar_file = f'{drop_extension(trk_file)}.json'
             if not op.exists(sidecar_file):
                 raise ValueError((
                     "JSON sidecars are required for trk files. "

--- a/AFQ/utils/tests/test_path.py
+++ b/AFQ/utils/tests/test_path.py
@@ -1,5 +1,6 @@
 from AFQ.utils.path import drop_extension
 
+
 def test_drop_extension():
     assert "/my/.example/.path/to_file" == drop_extension(
         "/my/.example/.path/to_file.nii.gz")

--- a/AFQ/utils/tests/test_path.py
+++ b/AFQ/utils/tests/test_path.py
@@ -1,0 +1,5 @@
+from AFQ.utils.path import drop_extension
+
+def test_drop_extension():
+    assert "/my/.example/.path/to_file" == drop_extension(
+        "/my/.example/.path/to_file.nii.gz")

--- a/AFQ/utils/tests/test_path.py
+++ b/AFQ/utils/tests/test_path.py
@@ -4,6 +4,6 @@ from AFQ.utils.path import drop_extension
 def test_drop_extension():
     assert "/my/.example/.path/to_file" == drop_extension(
         "/my/.example/.path/to_file.nii.gz")
-    
-    assert "C:\Documents\Newsletters\Summer2018" == drop_extension(
-        "C:\Documents\Newsletters\Summer2018.pdf.gz")
+
+    assert "C:\\Documents\\Newsletters\\Summer2018" == drop_extension(
+        "C:\\Documents\\Newsletters\\Summer2018.pdf.gz")

--- a/AFQ/utils/tests/test_path.py
+++ b/AFQ/utils/tests/test_path.py
@@ -4,3 +4,6 @@ from AFQ.utils.path import drop_extension
 def test_drop_extension():
     assert "/my/.example/.path/to_file" == drop_extension(
         "/my/.example/.path/to_file.nii.gz")
+    
+    assert "C:\Documents\Newsletters\Summer2018" == drop_extension(
+        "C:\Documents\Newsletters\Summer2018.pdf.gz")


### PR DESCRIPTION
Once this is merged, we should consider a minor release as this is needed to work with QSIprep