### PR TITLE
[WIP] [ENH] Add custom bundle recognizer

### DIFF
--- a/AFQ/api/custom_recognizer.py
+++ b/AFQ/api/custom_recognizer.py
@@ -1,0 +1,1 @@
+# put custom recognition functions here

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -810,6 +810,10 @@ class Segmentation:
                 self.logger.info("After filtering "
                                  f"{len(select_sl)} streamlines")
 
+            if "custom_recognizer" in self.bundle_dict[bundle]:
+                select_sl = self.bundle_dict[bundle]["custom_recognizer"](
+                    select_sl, self.img)
+
             if self.clip_edges:
                 self.logger.info("Clipping Streamlines by ROI")
                 for idx in range(len(select_sl)):

--- a/docs/source/usage/bundledict.rst
+++ b/docs/source/usage/bundledict.rst
@@ -19,5 +19,12 @@ key-value pairs::
     transformed from template to subject space before being used.
     - 'prob_map' : path to a Nifti file which is the probability map,
       optional.
+    - 'custom_recognizer' : function which accepts two arguments: (1) array of
+      streamlines of shape Kx3xN where K is the number of found streamlines, 
+      and N is the number of points in each streamline (default is 100), and
+      (2) a Nifti1Image for reference. Should return an array of streamlines
+      of shape Lx3xN, where L is the number of accepted streamlines. This
+      function is called near the end of bundle recognition, after cleaning
+      by endpoints but before the optional ROI clipping.
 
 For an example, see "Plotting the Optic Radiations" in :ref:`examples`.


### PR DESCRIPTION
We can use this during a code review for adding the VOF.
This are the criterion for VOF:

1. Fibers have one endpoint on the ventral surface. This can be done by taking the regions of the atlas that are on the ventral surface
2. Fibers have a primary orientation in the Z axis. We could write a simple function to compute each fibers primary orientation
3. fibers are posterior to the arcuate fascicules

This are addressed: 1) using endpoint interface, 3) either using prob map or exclusion ROI based on fascicules prob map, and 2) using this PR

See #430 

