### PR TITLE
[ENH] Apply arbitrary command to some/all pyAFQ outputs, more BIDSy names

### DIFF
--- a/AFQ/api/group.py
+++ b/AFQ/api/group.py
@@ -485,7 +485,7 @@ class GroupAFQ(object):
         self.logger.info(
             f"Time taken for export all: {str(time() - start_time)}")
 
-    def cmd_outputs(self, cmd="rm", dependent_on=None):
+    def cmd_outputs(self, cmd="rm", dependent_on=None, exceptions=[]):
         """
         Perform some command some or all outputs of pyafq.
         This is useful if you change a parameter and need
@@ -505,9 +505,12 @@ class GroupAFQ(object):
             If "recog", perform on all derivatives that depend on the
             bundle recognition.
             Default: None
+        exceptions : list of str
+            Name outputs that the command should not be applied to.
+            Default: []
         """
         for pAFQ in self.pAFQ_list:
-            pAFQ.cmd_outputs(cmd, dependent_on)
+            pAFQ.cmd_outputs(cmd, dependent_on, exceptions)
 
     def montage(self, bundle_name, size, view, slice_pos=None):
         """

--- a/AFQ/api/group.py
+++ b/AFQ/api/group.py
@@ -241,6 +241,7 @@ class GroupAFQ(object):
 
         self.valid_sub_list = []
         self.valid_ses_list = []
+        self.pAFQ_list = []
         for subject in self.subjects:
             self.wf_dict[subject] = {}
             for session in self.sessions:
@@ -298,6 +299,7 @@ class GroupAFQ(object):
                         "session": session},
                     **this_kwargs)
                 self.wf_dict[subject][str(session)] = this_pAFQ.wf_dict
+                self.pAFQ_list.append(this_pAFQ)
 
     def combine_profiles(self):
         tract_profiles_dict = self.export("profiles")
@@ -482,6 +484,30 @@ class GroupAFQ(object):
             self.assemble_AFQ_browser()
         self.logger.info(
             f"Time taken for export all: {str(time() - start_time)}")
+
+    def cmd_outputs(self, cmd="rm", dependent_on=None):
+        """
+        Perform some command some or all outputs of pyafq.
+        This is useful if you change a parameter and need
+        to recalculate derivatives that depend on it.
+        Some examples: cp, mv, rm .
+        -r will be automtically added when necessary.
+
+        Parameters
+        ----------
+        cmd : str
+            Command to run on outputs. Default: 'rm'
+        dependent_on : str or None
+            Which derivatives to perform command on .
+            If None, perform on all.
+            If "track", perform on all derivatives that depend on the
+            tractography.
+            If "recog", perform on all derivatives that depend on the
+            bundle recognition.
+            Default: None
+        """
+        for pAFQ in self.pAFQ_list:
+            pAFQ.cmd_outputs(cmd, dependent_on)
 
     def montage(self, bundle_name, size, view, slice_pos=None):
         """

--- a/AFQ/api/participant.py
+++ b/AFQ/api/participant.py
@@ -181,7 +181,7 @@ class ParticipantAFQ(object):
         self.logger.info(
             f"Time taken for export all: {time() - start_time}")
 
-    def cmd_outputs(self, cmd="rm", dependent_on=None):
+    def cmd_outputs(self, cmd="rm", dependent_on=None, exceptions=[]):
         """
         Perform some command some or all outputs of pyafq.
         This is useful if you change a parameter and need
@@ -201,6 +201,9 @@ class ParticipantAFQ(object):
             If "recog", perform on all derivatives that depend on the
             bundle recognition.
             Default: None
+        exceptions : list of str
+            Name outputs that the command should not be applied to.
+            Default: []
         """
         if dependent_on is None:
             dependent_on_list = ["trk", "rec", "dwi"]
@@ -213,7 +216,19 @@ class ParticipantAFQ(object):
                 "dependent_on must be one of "
                 "None, 'track', or 'recog'."))
 
+        exception_file_names = []
+        for exception in exceptions:
+            file_name = self.export(exception)
+            if isinstance(file_name, str):
+                exception_file_names.append(file_name)
+            else:
+                self.logger.warn((
+                    f"The exception '{exception}' does not correspond"
+                    " to a filename and will be ignored."))
+
         for filename in os.listdir(self.output_dir):
+            if filename in exception_file_names:
+                continue
             full_path = os.path.join(self.output_dir, filename)
             if os.path.isfile(full_path) or os.path.islink(full_path):
                 if not filename.endswith("json"):

--- a/AFQ/api/participant.py
+++ b/AFQ/api/participant.py
@@ -1,7 +1,6 @@
 import nibabel as nib
 import os.path as op
 import os
-import shutil
 from time import time
 import logging
 

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -288,7 +288,7 @@ class GeneratedMapMixin(object):
         mapping_file = get_fname(
             base_fname,
             '_mapping_from-DWI_to-MNI_xfm')
-        meta_fname = get_fname(base_fname, '_mapping_reg')
+        meta_fname = get_fname(base_fname, '_mapping_from-DWI_to-MNI_xfm')
         mapping_file = mapping_file + extension
         meta_fname = f'{meta_fname}.json'
         return mapping_file, meta_fname
@@ -304,6 +304,7 @@ class GeneratedMapMixin(object):
                 **self.affine_kwargs)
             meta = dict(
                 type="rigid",
+                dependent="dwi",
                 timing=time() - start_time)
             if not save:
                 return aff
@@ -337,6 +338,10 @@ class GeneratedMapMixin(object):
             meta = dict(
                 type="displacementfield",
                 timing=total_time)
+            if subject_sls is None:
+                meta["dependent"] = "dwi"
+            else:
+                meta["dependent"] = "trk"
             afs.write_json(meta_fname, meta)
         reg_prealign_inv = np.linalg.inv(reg_prealign) if self.use_prealign\
             else None

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -287,15 +287,15 @@ class GeneratedMapMixin(object):
     def get_fnames(self, extension, base_fname):
         mapping_file = get_fname(
             base_fname,
-            '_mapping_from-DWI_to-MNI_xfm')
-        meta_fname = get_fname(base_fname, '_mapping_from-DWI_to-MNI_xfm')
+            '_desc-mapping_from-DWI_to-MNI_xform')
+        meta_fname = f'{mapping_file}.json'
         mapping_file = mapping_file + extension
-        meta_fname = f'{meta_fname}.json'
         return mapping_file, meta_fname
 
     def prealign(self, base_fname, reg_subject, reg_template, save=True):
+        prealign_file_desc = "_desc-prealign_from-DWI_to-MNI_xform"
         prealign_file = get_fname(
-            base_fname, '_prealign_from-DWI_to-MNI_xfm.npy')
+            base_fname, f'{prealign_file_desc}.npy')
         if not op.exists(prealign_file):
             start_time = time()
             _, aff = affine_registration(
@@ -311,7 +311,7 @@ class GeneratedMapMixin(object):
             logger.info(f"Saving {prealign_file}")
             np.save(prealign_file, aff)
             meta_fname = get_fname(
-                base_fname, '_prealign_from-DWI_to-MNI_xfm.json')
+                base_fname, f'{prealign_file_desc}.json')
             afs.write_json(meta_fname, meta)
         return prealign_file if save else np.load(prealign_file)
 

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -287,7 +287,7 @@ class GeneratedMapMixin(object):
     def get_fnames(self, extension, base_fname):
         mapping_file = get_fname(
             base_fname,
-            '_mapping_from-DWI_to_MNI_xfm')
+            '_mapping_from-DWI_to-MNI_xfm')
         meta_fname = get_fname(base_fname, '_mapping_reg')
         mapping_file = mapping_file + extension
         meta_fname = f'{meta_fname}.json'

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -77,7 +77,7 @@ def get_data_gtab(dwi, bval, bvec, min_bval=None,
 
 
 @pimms.calc("b0")
-@as_file('_b0.nii.gz')
+@as_file('_desc-b0_dwi.nii.gz')
 def b0(dwi, data, gtab, img):
     """
     full path to a nifti file containing the mean b0
@@ -90,7 +90,7 @@ def b0(dwi, data, gtab, img):
 
 
 @pimms.calc("masked_b0")
-@as_file('_maskedb0.nii.gz')
+@as_file('_desc-maskedb0_dwi.nii.gz')
 def b0_mask(base_fname, b0, brain_mask):
     """
     full path to a nifti file containing the
@@ -104,7 +104,7 @@ def b0_mask(base_fname, b0, brain_mask):
 
     masked_b0_img = nib.Nifti1Image(masked_data, img.affine)
     meta = dict(
-        source=get_fname(base_fname, '_b0.nii.gz'),
+        source=b0,
         masked=True)
     return masked_b0_img, meta
 
@@ -117,7 +117,7 @@ def dti_fit(dti_params, gtab):
     return dpy_dti.TensorFit(tm, dti_params)
 
 
-@as_file(suffix='_model-DTI_diffmodel.nii.gz')
+@as_file(suffix='_model-DTI_desc-diffmodel_dwi.nii.gz')
 @as_img
 def dti(brain_mask, data, gtab,
         bval, bvec, b0_threshold=50, robust_tensor_fitting=False):
@@ -167,7 +167,7 @@ def dki_fit(dki_params, gtab):
     return dpy_dki.DiffusionKurtosisFit(tm, dki_params)
 
 
-@as_file(suffix='_model-DKI_diffmodel.nii.gz')
+@as_file(suffix='_model-DKI_desc-diffmodel_dwi.nii.gz')
 @as_img
 def dki(brain_mask, gtab, data):
     """
@@ -190,7 +190,7 @@ def dki(brain_mask, gtab, data):
 dki_params = pimms.calc("dki_params")(dki)
 
 
-@as_file(suffix='_model-CSD_diffmodel.nii.gz')
+@as_file(suffix='_model-CSD_desc-diffmodel_dwi.nii.gz')
 @as_img
 def csd(dwi, brain_mask, gtab, data,
         csd_response=None, csd_sh_order=None,
@@ -257,7 +257,7 @@ csd_params = pimms.calc("csd_params")(csd)
 
 
 @pimms.calc("pmap")
-@as_file(suffix='_model-CSD_APM.nii.gz')
+@as_file(suffix='_model-CSD_desc-APM_dwi.nii.gz')
 def anisotropic_power_map(csd_params):
     """
     full path to a nifti file containing
@@ -270,7 +270,7 @@ def anisotropic_power_map(csd_params):
 
 
 @pimms.calc("dti_fa")
-@as_file(suffix='_model-DTI_FA.nii.gz')
+@as_file(suffix='_model-DTI_desc-FA_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_fa(dti_tf):
     """
@@ -299,7 +299,7 @@ def dti_lt(dti_tf, dwi_affine):
 
 
 @pimms.calc("dti_cfa")
-@as_file(suffix='_model-DTI_desc-DEC_FA.nii.gz')
+@as_file(suffix='_model-DTI_desc-CFA_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_cfa(dti_tf):
     """
@@ -310,7 +310,7 @@ def dti_cfa(dti_tf):
 
 
 @pimms.calc("dti_pdd")
-@as_file(suffix='_model-DTI_PDD.nii.gz')
+@as_file(suffix='_model-DTI_desc-PDD_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_pdd(dti_tf):
     """
@@ -324,7 +324,7 @@ def dti_pdd(dti_tf):
 
 
 @pimms.calc("dti_md")
-@as_file('_model-DTI_MD.nii.gz')
+@as_file('_model-DTI_desc-MD_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_md(dti_tf):
     """
@@ -335,7 +335,7 @@ def dti_md(dti_tf):
 
 
 @pimms.calc("dti_ga")
-@as_file(suffix='_model-DTI_GA.nii.gz')
+@as_file(suffix='_model-DTI_desc-GA_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_ga(dti_tf):
     """
@@ -346,7 +346,7 @@ def dti_ga(dti_tf):
 
 
 @pimms.calc("dti_rd")
-@as_file(suffix='_model-DTI_RD.nii.gz')
+@as_file(suffix='_model-DTI_desc-RD_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_rd(dti_tf):
     """
@@ -357,7 +357,7 @@ def dti_rd(dti_tf):
 
 
 @pimms.calc("dti_ad")
-@as_file(suffix='_model-DTI_AD.nii.gz')
+@as_file(suffix='_model-DTI_desc-AD_dwi.nii.gz')
 @as_fit_deriv('DTI')
 def dti_ad(dti_tf):
     """
@@ -368,7 +368,7 @@ def dti_ad(dti_tf):
 
 
 @pimms.calc("dki_fa")
-@as_file('_model-DKI_FA.nii.gz')
+@as_file('_model-DKI_desc-FA_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_fa(dki_tf):
     """
@@ -379,7 +379,7 @@ def dki_fa(dki_tf):
 
 
 @pimms.calc("dki_md")
-@as_file('_model-DKI_MD.nii.gz')
+@as_file('_model-DKI_desc-MD_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_md(dki_tf):
     """
@@ -390,7 +390,7 @@ def dki_md(dki_tf):
 
 
 @pimms.calc("dki_awf")
-@as_file('_model-DKI_AWF.nii.gz')
+@as_file('_model-DKI_desc-AWF_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_awf(dki_params,
             sphere='repulsion100', gtol=1e-2):
@@ -418,7 +418,7 @@ def dki_awf(dki_params,
 
 
 @pimms.calc("dki_mk")
-@as_file('_model-DKI_MK.nii.gz')
+@as_file('_model-DKI_desc-MK_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_mk(dki_tf):
     """
@@ -429,7 +429,7 @@ def dki_mk(dki_tf):
 
 
 @pimms.calc("dki_ga")
-@as_file(suffix='_model-DKI_GA.nii.gz')
+@as_file(suffix='_model-DKI_desc-GA_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_ga(dki_tf):
     """
@@ -440,7 +440,7 @@ def dki_ga(dki_tf):
 
 
 @pimms.calc("dki_rd")
-@as_file(suffix='_model-DKI_RD.nii.gz')
+@as_file(suffix='_model-DKI_desc-RD_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_rd(dki_tf):
     """
@@ -451,7 +451,7 @@ def dki_rd(dki_tf):
 
 
 @pimms.calc("dki_ad")
-@as_file(suffix='_model-DKI_AD.nii.gz')
+@as_file(suffix='_model-DKI_desc-AD_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_ad(dki_tf):
     """
@@ -462,7 +462,7 @@ def dki_ad(dki_tf):
 
 
 @pimms.calc("dki_rk")
-@as_file(suffix='_model-DKI_RK.nii.gz')
+@as_file(suffix='_model-DKI_desc-RK_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_rk(dki_tf):
     """
@@ -473,7 +473,7 @@ def dki_rk(dki_tf):
 
 
 @pimms.calc("dki_ak")
-@as_file(suffix='_model-DKI_AK.nii.gz')
+@as_file(suffix='_model-DKI_desc-AK_dwi.nii.gz')
 @as_fit_deriv('DKI')
 def dki_ak(dki_tf):
     """
@@ -484,7 +484,7 @@ def dki_ak(dki_tf):
 
 
 @pimms.calc("brain_mask")
-@as_file('_brainMask.nii.gz')
+@as_file('_desc-brain_mask.nii.gz')
 def brain_mask(base_fname, dwi, b0,
                bids_info, brain_mask_definition=None):
     """

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -484,7 +484,7 @@ def dki_ak(dki_tf):
 
 
 @pimms.calc("brain_mask")
-@as_file('_brain_mask.nii.gz')
+@as_file('_brainMask.nii.gz')
 def brain_mask(base_fname, dwi, b0,
                bids_info, brain_mask_definition=None):
     """

--- a/AFQ/tasks/decorators.py
+++ b/AFQ/tasks/decorators.py
@@ -139,6 +139,14 @@ def as_file(suffix, include_track=False, include_seg=False):
                         img_trk_or_csv, this_file, bbox_valid_check=False)
                 else:
                     img_trk_or_csv.to_csv(this_file)
+
+                if include_seg:
+                    meta["dependent"] = "rec"
+                elif include_track:
+                    meta["dependent"] = "trk"
+                else:
+                    meta["dependent"] = "dwi"
+
                 meta_fname = get_fname(
                     base_fname, f"{drop_extension(suffix)}.json",
                     tracking_params=tracking_params,

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -6,7 +6,7 @@ import logging
 
 import pimms
 from AFQ.tasks.decorators import as_file
-from AFQ.tasks.utils import get_fname, with_name
+from AFQ.tasks.utils import get_fname, with_name, str_to_desc
 import AFQ.data.fetch as afd
 from AFQ.data.s3bids import write_json
 from AFQ.utils.path import drop_extension
@@ -23,7 +23,7 @@ logger = logging.getLogger('AFQ.api.mapping')
 
 
 @pimms.calc("b0_warped")
-@as_file('_b0InMNI.nii.gz')
+@as_file('_space-template_desc-b0_dwi.nii.gz')
 def export_registered_b0(data_imap, mapping):
     """
     full path to a nifti file containing
@@ -36,7 +36,7 @@ def export_registered_b0(data_imap, mapping):
 
 
 @pimms.calc("template_xform")
-@as_file('_templateXform.nii.gz')
+@as_file('_space-subject_desc-template_dwi.nii.gz')
 def template_xform(dwi_affine, mapping, data_imap):
     """
     full path to a nifti file containing
@@ -66,7 +66,9 @@ def export_rois(base_fname, results_dir, data_imap, mapping, dwi_affine):
                     fname = op.split(
                         get_fname(
                             base_fname,
-                            f'_desc-ROI-{bundle}-{ii + 1}-{roi_type}.nii.gz'))
+                            '_space-subject_desc-'
+                            f'{str_to_desc(bundle)}{ii + 1}{roi_type}'
+                            '_mask.nii.gz'))
 
                     fname = op.join(rois_dir, fname[1])
                     if not op.exists(fname):
@@ -256,8 +258,10 @@ def get_mapping_plan(kwargs, use_sls=False):
                 )
             mapping_tasks[f"{scalar.get_name()}_res"] =\
                 pimms.calc(f"{scalar.get_name()}")(
-                    as_file(f'-{scalar.get_name()}.nii.gz')(
-                        scalar.get_image_getter("mapping")))
+                    as_file((
+                        f'desc-{str_to_desc(scalar.get_name())}'
+                        '_dwi.nii.gz'))(
+                            scalar.get_image_getter("mapping")))
 
     if use_sls:
         mapping_tasks["mapping_res"] = sls_mapping

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('AFQ.api.mapping')
 
 
 @pimms.calc("b0_warped")
-@as_file('_b0_in_MNI.nii.gz')
+@as_file('_b0InMNI.nii.gz')
 def export_registered_b0(data_imap, mapping):
     """
     full path to a nifti file containing
@@ -36,7 +36,7 @@ def export_registered_b0(data_imap, mapping):
 
 
 @pimms.calc("template_xform")
-@as_file('_template_xform.nii.gz')
+@as_file('_templateXform.nii.gz')
 def template_xform(dwi_affine, mapping, data_imap):
     """
     full path to a nifti file containing

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -83,7 +83,7 @@ def segment(dwi, data_imap, mapping_imap,
 
 
 @pimms.calc("clean_bundles")
-@as_file('-cleanTractography.trk', include_track=True, include_seg=True)
+@as_file('_desc-clean_tractography.trk', include_track=True, include_seg=True)
 def clean_bundles(bundles, data_imap, clean_params=None):
     """
     full path to a trk file containting segmented

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -9,7 +9,7 @@ import logging
 import pimms
 
 from AFQ.tasks.decorators import as_file
-from AFQ.tasks.utils import get_fname, with_name
+from AFQ.tasks.utils import get_fname, with_name, str_to_desc
 import AFQ.segmentation as seg
 from AFQ.utils.path import drop_extension
 import AFQ.utils.streamlines as aus
@@ -169,7 +169,7 @@ def export_bundles(base_fname, results_dir,
                 fname = op.split(
                     get_fname(
                         base_fname,
-                        f'-{bundle}'
+                        f'_desc-{str_to_desc(bundle)}'
                         f'_tractography.trk',
                         tracking_params=tracking_params,
                         segmentation_params=segmentation_params))
@@ -185,7 +185,7 @@ def export_bundles(base_fname, results_dir,
 
 
 @pimms.calc("sl_counts")
-@as_file('_slCount.csv', include_track=True, include_seg=True)
+@as_file('_desc-slCount_dwi.csv', include_track=True, include_seg=True)
 def export_sl_counts(data_imap,
                      clean_bundles, bundles):
     """
@@ -218,7 +218,7 @@ def export_sl_counts(data_imap,
 
 
 @pimms.calc("median_bundle_lengths")
-@as_file('_medianBundleLengths.csv', include_track=True, include_seg=True)
+@as_file('_desc-medianBundleLengths_dwi.csv', include_track=True, include_seg=True)
 def export_bundle_lengths(data_imap,
                           clean_bundles, bundles):
     """
@@ -258,7 +258,7 @@ def export_bundle_lengths(data_imap,
 
 
 @pimms.calc("profiles")
-@as_file('_profiles.csv', include_track=True, include_seg=True)
+@as_file('_desc-profiles_dwi.csv', include_track=True, include_seg=True)
 def tract_profiles(clean_bundles, data_imap,
                    scalar_dict, dwi_affine,
                    profile_weights="gauss"):

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -83,7 +83,7 @@ def segment(dwi, data_imap, mapping_imap,
 
 
 @pimms.calc("clean_bundles")
-@as_file('-clean_tractography.trk', include_track=True, include_seg=True)
+@as_file('-cleanTractography.trk', include_track=True, include_seg=True)
 def clean_bundles(bundles, data_imap, clean_params=None):
     """
     full path to a trk file containting segmented
@@ -185,7 +185,7 @@ def export_bundles(base_fname, results_dir,
 
 
 @pimms.calc("sl_counts")
-@as_file('_sl_count.csv', include_track=True, include_seg=True)
+@as_file('_slCount.csv', include_track=True, include_seg=True)
 def export_sl_counts(data_imap,
                      clean_bundles, bundles):
     """

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -218,7 +218,9 @@ def export_sl_counts(data_imap,
 
 
 @pimms.calc("median_bundle_lengths")
-@as_file('_desc-medianBundleLengths_dwi.csv', include_track=True, include_seg=True)
+@as_file(
+    '_desc-medianBundleLengths_dwi.csv',
+    include_track=True, include_seg=True)
 def export_bundle_lengths(data_imap,
                           clean_bundles, bundles):
     """

--- a/AFQ/tasks/tractography.py
+++ b/AFQ/tasks/tractography.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('AFQ.api')
 
 
 @pimms.calc("seed")
-@as_file('_seedMask.nii.gz')
+@as_file('_desc-seed_mask.nii.gz')
 @as_img
 def export_seed_mask(tracking_params):
     """
@@ -28,7 +28,7 @@ def export_seed_mask(tracking_params):
 
 
 @pimms.calc("stop")
-@as_file('_stopMask.nii.gz')
+@as_file('_desc-stop_mask.nii.gz')
 @as_img
 def export_stop_mask(tracking_params):
     """
@@ -242,12 +242,12 @@ def get_tractography_plan(kwargs):
             export_stop_mask_pft
     elif isinstance(stop_mask, Definition):
         tractography_tasks["export_stop_mask_res"] =\
-            pimms.calc("stop")(as_file('_stop_mask.nii.gz')(
+            pimms.calc("stop")(as_file('_desc-stop_mask.nii.gz')(
                 stop_mask.get_image_getter("tractography")))
 
     if isinstance(seed_mask, Definition):
         tractography_tasks["export_seed_mask_res"] = pimms.calc("seed")(
-            as_file('_seed_mask.nii.gz')(
+            as_file('_desc-seed_mask.nii.gz')(
                 seed_mask.get_image_getter("tractography")))
 
     return pimms.plan(**tractography_tasks)

--- a/AFQ/tasks/tractography.py
+++ b/AFQ/tasks/tractography.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('AFQ.api')
 
 
 @pimms.calc("seed")
-@as_file('_seed_mask.nii.gz')
+@as_file('_seedMask.nii.gz')
 @as_img
 def export_seed_mask(tracking_params):
     """
@@ -28,7 +28,7 @@ def export_seed_mask(tracking_params):
 
 
 @pimms.calc("stop")
-@as_file('_stop_mask.nii.gz')
+@as_file('_stopMask.nii.gz')
 @as_img
 def export_stop_mask(tracking_params):
     """

--- a/AFQ/tasks/utils.py
+++ b/AFQ/tasks/utils.py
@@ -31,3 +31,7 @@ def get_default_args(func):
         for k, v in inspect.signature(func).parameters.items()
         if v.default is not inspect.Parameter.empty
     }
+
+
+def str_to_desc(string):
+    return string.replace("-", "").replace("_", "")

--- a/AFQ/tasks/utils.py
+++ b/AFQ/tasks/utils.py
@@ -11,8 +11,7 @@ def get_fname(base_fname, suffix,
         odf_model = tracking_params['odf_model']
         directions = tracking_params['directions']
         fname = fname + (
-            f'_space-RASMM_model-{odf_model}'
-            f'_desc-{directions}'
+            f'_space-RASMM_model-{directions+odf_model}'
         )
     if segmentation_params is not None and 'seg_algo' in segmentation_params:
         seg_algo = segmentation_params['seg_algo']

--- a/AFQ/tasks/utils.py
+++ b/AFQ/tasks/utils.py
@@ -7,8 +7,6 @@ __all__ = ["get_fname", "with_name"]
 def get_fname(base_fname, suffix,
               tracking_params=None, segmentation_params=None):
     fname = base_fname
-    using_trk = False
-    using_seg = False
     if tracking_params is not None and 'odf_model' in tracking_params:
         odf_model = tracking_params['odf_model']
         directions = tracking_params['directions']
@@ -16,16 +14,9 @@ def get_fname(base_fname, suffix,
             f'_space-RASMM_model-{odf_model}'
             f'_desc-{directions}'
         )
-        using_trk = True
     if segmentation_params is not None and 'seg_algo' in segmentation_params:
         seg_algo = segmentation_params['seg_algo']
-        using_seg = True
         fname = fname + f"_algo-{seg_algo}"
-
-    if using_seg:
-        fname = fname + "_dependent-rec"
-    elif using_trk:
-        fname = fname + "_dependent-trk"
 
     return fname + suffix
 

--- a/AFQ/tasks/utils.py
+++ b/AFQ/tasks/utils.py
@@ -11,12 +11,13 @@ def get_fname(base_fname, suffix,
         odf_model = tracking_params['odf_model']
         directions = tracking_params['directions']
         fname = fname + (
+            "_dependent-trk"
             f'_space-RASMM_model-{odf_model}'
             f'_desc-{directions}'
         )
     if segmentation_params is not None and 'seg_algo' in segmentation_params:
         seg_algo = segmentation_params['seg_algo']
-        fname = f'{fname}-{seg_algo}'
+        fname = f'{fname}_dependent-rec_algo-{seg_algo}'
 
     return fname + suffix
 

--- a/AFQ/tasks/utils.py
+++ b/AFQ/tasks/utils.py
@@ -7,17 +7,25 @@ __all__ = ["get_fname", "with_name"]
 def get_fname(base_fname, suffix,
               tracking_params=None, segmentation_params=None):
     fname = base_fname
+    using_trk = False
+    using_seg = False
     if tracking_params is not None and 'odf_model' in tracking_params:
         odf_model = tracking_params['odf_model']
         directions = tracking_params['directions']
         fname = fname + (
-            "_dependent-trk"
             f'_space-RASMM_model-{odf_model}'
             f'_desc-{directions}'
         )
+        using_trk = True
     if segmentation_params is not None and 'seg_algo' in segmentation_params:
         seg_algo = segmentation_params['seg_algo']
-        fname = f'{fname}_dependent-rec_algo-{seg_algo}'
+        using_seg = True
+        fname = fname + f"_algo-{seg_algo}"
+
+    if using_seg:
+        fname = fname + "_dependent-rec"
+    elif using_trk:
+        fname = fname + "_dependent-trk"
 
     return fname + suffix
 

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -10,7 +10,7 @@ import pimms
 
 from dipy.align import resample
 
-from AFQ.tasks.utils import get_fname, with_name
+from AFQ.tasks.utils import get_fname, with_name, str_to_desc
 import AFQ.utils.volume as auv
 from AFQ.data.s3bids import write_json
 from AFQ.viz.utils import Viz
@@ -119,20 +119,20 @@ def viz_bundles(base_fname,
     fname = None
     if "no_gif" not in viz_backend.backend:
         fname = get_fname(
-            base_fname, '_viz.gif',
+            base_fname, '_desc-viz_dwi.gif',
             tracking_params=tracking_params,
             segmentation_params=segmentation_params)
 
         viz_backend.create_gif(figure, fname)
     if "plotly" in viz_backend.backend:
         fname = get_fname(
-            base_fname, '_viz.html',
+            base_fname, '_desc-viz_dwi.html',
             tracking_params=tracking_params,
             segmentation_params=segmentation_params)
 
         figure.write_html(fname)
     meta_fname = get_fname(
-        base_fname, '_viz.json',
+        base_fname, '_desc-viz_dwi.json',
         tracking_params=tracking_params,
         segmentation_params=segmentation_params)
     meta = dict(Timing=time() - start_time)
@@ -266,8 +266,8 @@ def viz_indivBundle(base_fname,
             fname = op.split(
                 get_fname(
                     base_fname,
-                    f'_{bundle_name}'
-                    f'_viz.gif',
+                    f'_desc-{str_to_desc(bundle_name)}viz'
+                    f'_dwi.gif',
                     tracking_params=tracking_params,
                     segmentation_params=segmentation_params))
 
@@ -280,8 +280,8 @@ def viz_indivBundle(base_fname,
             fname = op.split(
                 get_fname(
                     base_fname,
-                    f'_{bundle_name}'
-                    f'_viz.html',
+                    f'_desc-{str_to_desc(bundle_name)}viz'
+                    f'_dwi.html',
                     tracking_params=tracking_params,
                     segmentation_params=segmentation_params))
 
@@ -298,8 +298,8 @@ def viz_indivBundle(base_fname,
                 fname = op.split(
                     get_fname(
                         base_fname,
-                        f'_{bundle_name}'
-                        f'_viz.html',
+                        f'_desc-{str_to_desc(bundle_name)}viz'
+                        f'_dwi.html',
                         tracking_params=tracking_params,
                         segmentation_params=segmentation_params))
                 fname = op.join(core_dir, fname[1])
@@ -336,7 +336,7 @@ def viz_indivBundle(base_fname,
                     include_profile=True)
                 core_fig.write_html(fname)
     meta_fname = get_fname(
-        base_fname, '_vizIndiv.json',
+        base_fname, f'_desc-{str_to_desc(bundle_name)}viz_dwi',
         tracking_params=tracking_params,
         segmentation_params=segmentation_params)
     meta = dict(Timing=time() - start_time)
@@ -357,7 +357,7 @@ def plot_tract_profiles(base_fname, scalars, tracking_params,
     for scalar in scalars:
         this_scalar = scalar if isinstance(scalar, str) else scalar.get_name()
         fname = get_fname(
-            base_fname, f'_{this_scalar}_profile_plots',
+            base_fname, f'_model-{str_to_desc(this_scalar)}_desc-vizprofile_dwi',
             tracking_params=tracking_params,
             segmentation_params=segmentation_params)
         tract_profiles_folder = op.join(
@@ -373,14 +373,10 @@ def plot_tract_profiles(base_fname, scalars, tracking_params,
             scalar=this_scalar,
             file_name=fname,
             n_boot=100)
-        fnames.append(fname)
-    meta_fname = get_fname(
-        base_fname, '_profile_plots.json',
-        tracking_params=tracking_params,
-        segmentation_params=segmentation_params)
-    meta = dict(Timing=time() - start_time)
-    write_json(meta_fname, meta)
-
+        fnames.append(fname + ".png")
+        meta_fname = fname + ".json"
+        meta = dict(Timing=time() - start_time)
+        write_json(meta_fname, meta)
     return fnames
 
 

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -357,7 +357,8 @@ def plot_tract_profiles(base_fname, scalars, tracking_params,
     for scalar in scalars:
         this_scalar = scalar if isinstance(scalar, str) else scalar.get_name()
         fname = get_fname(
-            base_fname, f'_model-{str_to_desc(this_scalar)}_desc-vizprofile_dwi',
+            base_fname,
+            f'_model-{str_to_desc(this_scalar)}_desc-vizprofile_dwi',
             tracking_params=tracking_params,
             segmentation_params=segmentation_params)
         tract_profiles_folder = op.join(

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -745,11 +745,11 @@ def test_AFQ_data_waypoint():
 
     mapping_file = op.join(
         myafq.export("results_dir"),
-        'sub-01_ses-01_dwi_mapping_from-DWI_to-MNI_xfm.nii.gz')
+        'sub-01_ses-01_dwi_desc-mapping_from-DWI_to-MNI_xform.nii.gz')
     nib.save(mapping, mapping_file)
     reg_prealign_file = op.join(
         myafq.export("results_dir"),
-        'sub-01_ses-01_dwi_prealign_from-DWI_to-MNI_xfm.npy')
+        'sub-01_ses-01_dwi_desc-prealign_from-DWI_to-MNI_xform.npy')
     np.save(reg_prealign_file, np.eye(4))
 
     seg_sft = aus.SegmentedSFT.fromfile(
@@ -761,14 +761,14 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'ROIs',
-        'sub-01_ses-01_dwi_desc-ROI-CST_R-1-include.json'))
+        'sub-01_ses-01_dwi_desc-CSTR1include_mask.json'))
 
     # Test bundles exporting:
     myafq.export("indiv_bundles")
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_desc-SLFL_tractography.trk'))  # noqa
 
     tract_profile_fname = myafq.export("profiles")
     tract_profiles = pd.read_csv(tract_profile_fname)
@@ -780,12 +780,12 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_desc-SLFLviz_dwi.html'))  # noqa
 
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLFLviz_dwi.html'))  # noqa
 
     # Before we run the CLI, we'll remove the bundles and ROI folders, to see
     # that the CLI generates them
@@ -853,9 +853,9 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'ROIs',
-        'sub-01_ses-01_dwi_desc-ROI-SLF_L-1-include.json'))
+        'sub-01_ses-01_dwi_desc-SLFL1include_mask.json'))
 
     assert op.exists(op.join(
         results_dir,
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_desc-SLFL_tractography.trk'))  # noqa

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -768,7 +768,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ-SLF_L_tractography.trk'))  # noqa
 
     tract_profile_fname = myafq.export("profiles")
     tract_profiles = pd.read_csv(tract_profile_fname)
@@ -780,12 +780,12 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLF_L_viz.html'))  # noqa
 
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLF_L_viz.html'))  # noqa
 
     # Before we run the CLI, we'll remove the bundles and ROI folders, to see
     # that the CLI generates them
@@ -858,4 +858,4 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ-SLF_L_tractography.trk'))  # noqa

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -857,4 +857,4 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec-SLF_L_tractography.trk'))  # noqa

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -369,9 +369,9 @@ def test_AFQ_data():
         npt.assert_equal(nib.load(myafq.export("b0")["01"]).shape,
                          nib.load(myafq.export("dti_params")["01"]).shape[:3])
         myafq.export("rois")
-        shutil.rmtree(op.join(
-            bids_path,
-            'derivatives/afq'))
+        myafq.cmd_outputs()
+        assert len(os.listdir(op.join(
+            myafq.afq_path, "sub-01", "ses-01"))) == 0
 
 
 @pytest.mark.nightly_anisotropic
@@ -744,7 +744,7 @@ def test_AFQ_data_waypoint():
 
     mapping_file = op.join(
         myafq.export("results_dir"),
-        'sub-01_ses-01_dwi_mapping_from-DWI_to_MNI_xfm.nii.gz')
+        'sub-01_ses-01_dwi_mapping_from-DWI_to-MNI_xfm.nii.gz')
     nib.save(mapping, mapping_file)
     reg_prealign_file = op.join(
         myafq.export("results_dir"),

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -767,7 +767,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec-SLF_L_tractography.trk'))  # noqa
 
     tract_profile_fname = myafq.export("profiles")
     tract_profiles = pd.read_csv(tract_profile_fname)
@@ -779,12 +779,12 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_viz.html'))  # noqa
 
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob-AFQ_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_viz.html'))  # noqa
 
     # Before we run the CLI, we'll remove the bundles and ROI folders, to see
     # that the CLI generates them
@@ -857,4 +857,4 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob-AFQ-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_tractography.trk'))  # noqa

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -456,6 +456,7 @@ def test_API_type_checking():
                 suffix='dne_dne',
                 filters={'scope': 'dne_dne'}))
         myafq.export("brain_mask")
+    del myafq
 
     with pytest.raises(
             TypeError,
@@ -476,7 +477,7 @@ def test_API_type_checking():
                 affine_kwargs={
                     "level_iters": [1, 1],
                     "pipeline": ["center_of_mass"]}),
-            tracking_params={"n_seeds": 10, "random_seeds": True},
+            tracking_params={"n_seeds": 1, "random_seeds": True},
             bundle_info=["ARC_L", "ARC_R"])
         myafq.export("bundles")
     del myafq

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -761,7 +761,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'ROIs',
-        'sub-01_ses-01_dwi_desc-CSTR1include_mask.json'))
+        'sub-01_ses-01_dwi_space-subject_desc-CSTR1include_mask.json'))
 
     # Test bundles exporting:
     myafq.export("indiv_bundles")
@@ -785,7 +785,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_SLFLviz_dwi.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-probCSD_algo-AFQ_desc-SLFLviz_dwi.html'))  # noqa
 
     # Before we run the CLI, we'll remove the bundles and ROI folders, to see
     # that the CLI generates them
@@ -853,7 +853,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'ROIs',
-        'sub-01_ses-01_dwi_desc-SLFL1include_mask.json'))
+        'sub-01_ses-01_dwi_space-subject_desc-SLFL1include_mask.json'))
 
     assert op.exists(op.join(
         results_dir,

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -768,7 +768,7 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ-SLF_L_tractography.trk'))  # noqa
 
     tract_profile_fname = myafq.export("profiles")
     tract_profiles = pd.read_csv(tract_profile_fname)
@@ -780,12 +780,12 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_SLF_L_viz.html'))  # noqa
 
     assert op.exists(op.join(
         myafq.export("results_dir"),
         "viz_bundles",
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec_SLF_L_viz.html'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_SLF_L_viz.html'))  # noqa
 
     # Before we run the CLI, we'll remove the bundles and ROI folders, to see
     # that the CLI generates them
@@ -858,4 +858,4 @@ def test_AFQ_data_waypoint():
     assert op.exists(op.join(
         results_dir,
         'bundles',
-        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ_dependent-rec-SLF_L_tractography.trk'))  # noqa
+        'sub-01_ses-01_dwi_space-RASMM_model-CSD_desc-prob_algo-AFQ-SLF_L_tractography.trk'))  # noqa


### PR DESCRIPTION
This PR has two parts, both affect output file names.
1. Propose a framework for easily handling pyAFQ outputs according to what they dependent. In this case, we use a depends field we put in the json files. Also, you can exclude particular outputs if you want. This is, I think, a more elegant solution to #799 and #795
2. Make pyAFQ outputs follow a more BIDS-y format. Discussed previously in #819 