### PR TITLE
FIX: Reorder endpoint

### DIFF
--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -763,12 +763,20 @@ class Segmentation:
 
         # Eliminate any fibers not selected using the waypoint ROIs:
         possible_fibers = np.nansum(streamlines_in_bundles, -1) > 0
+        tg = StatefulTractogram(tg.streamlines[possible_fibers],
+                                self.img,
+                                Space.VOX)
         streamlines_in_bundles = streamlines_in_bundles[possible_fibers]
         min_dist_coords = min_dist_coords[possible_fibers]
         if self.roi_dist_tie_break:
             bundle_choice = np.nanargmin(np.nanmin(min_dist_coords, -1), -1)
         else:
             bundle_choice = np.nanargmax(streamlines_in_bundles, -1)
+
+        if self.save_intermediates is not None:
+            os.makedirs(self.save_intermediates, exist_ok=True)
+            bc_path = op.join(self.save_intermediates, "bundle_choice.npy")
+            np.save(bc_path, bundle_choice)
 
         # We do another round through, so that we can orient all the
         # streamlines within a bundle in the same orientation with respect to

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -536,8 +536,8 @@ class Segmentation:
                         prob_map.copy(),
                         interpolation='nearest')
 
-            return warped_prob_map, include_rois, exclude_rois,\
-                include_roi_tols, exclude_roi_tols
+        return warped_prob_map, include_rois, exclude_rois,\
+            include_roi_tols, exclude_roi_tols
 
     def _return_empty(self, bundle):
         """
@@ -769,18 +769,18 @@ class Segmentation:
         if self.return_idx:
             out_idx = out_idx[possible_fibers]
 
+        if self.save_intermediates is not None:
+            os.makedirs(self.save_intermediates, exist_ok=True)
+            bc_path = op.join(self.save_intermediates,
+                              "sls_bundle_assignment.npy")
+            np.save(bc_path, streamlines_in_bundles)
+
         streamlines_in_bundles = streamlines_in_bundles[possible_fibers]
         min_dist_coords = min_dist_coords[possible_fibers]
         if self.roi_dist_tie_break:
             bundle_choice = np.nanargmin(np.nanmin(min_dist_coords, -1), -1)
         else:
             bundle_choice = np.nanargmax(streamlines_in_bundles, -1)
-
-        if self.save_intermediates is not None:
-            os.makedirs(self.save_intermediates, exist_ok=True)
-            bc_path = op.join(self.save_intermediates,
-                              "sls_bundle_assignment.npy")
-            np.save(bc_path, streamlines_in_bundles)
 
         # We do another round through, so that we can orient all the
         # streamlines within a bundle in the same orientation with respect to

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -787,9 +787,9 @@ class Segmentation:
 
             # Use a list here, because ArraySequence doesn't support item
             # assignment:
-            select_sl = list(tg.streamlines[possible_fibers][select_idx])
+            select_sl = list(tg.streamlines[select_idx])
             # Sub-sample min_dist_coords:
-            min_dist_coords_bundle = min_dist_coords[possible_fibers]
+            min_dist_coords_bundle = min_dist_coords[select_idx]
             for idx in range(len(select_sl)):
                 min0 = min_dist_coords_bundle[idx, bundle_idx, 0]
                 min1 = min_dist_coords_bundle[idx, bundle_idx, 1]
@@ -818,8 +818,7 @@ class Segmentation:
             if self.return_idx:
                 self.fiber_groups[bundle] = {}
                 self.fiber_groups[bundle]['sl'] = select_sl
-                self.fiber_groups[bundle]['idx'] = out_idx[
-                    possible_fibers][select_idx]
+                self.fiber_groups[bundle]['idx'] = out_idx[select_idx]
             else:
                 self.fiber_groups[bundle] = select_sl
         return self.fiber_groups

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -516,25 +516,25 @@ class Segmentation:
                                 bundle,
                                 'as_used.nii.gz'))
 
-            # The probability map if doesn't exist is all ones with the same
-            # shape as the ROIs:
-            if isinstance(roi, str):
-                roi = nib.load(roi)
-            if isinstance(roi, nib.Nifti1Image):
-                roi = roi.get_fdata()
-            prob_map = bundle_entry.get(
-                'prob_map', np.ones(roi.shape))
+        # The probability map if doesn't exist is all ones with the same
+        # shape as the ROIs:
+        if isinstance(roi, str):
+            roi = nib.load(roi)
+        if isinstance(roi, nib.Nifti1Image):
+            roi = roi.get_fdata()
+        prob_map = bundle_entry.get(
+            'prob_map', np.ones(roi.shape))
 
-            if not isinstance(prob_map, np.ndarray):
-                prob_map = prob_map.get_fdata()
-            if "space" in bundle_entry\
-                    and bundle_entry["space"] == "subject":
-                warped_prob_map = prob_map.copy()
-            else:
-                warped_prob_map = \
-                    self.mapping.transform_inverse(
-                        prob_map.copy(),
-                        interpolation='nearest')
+        if not isinstance(prob_map, np.ndarray):
+            prob_map = prob_map.get_fdata()
+        if "space" in bundle_entry\
+                and bundle_entry["space"] == "subject":
+            warped_prob_map = prob_map.copy()
+        else:
+            warped_prob_map = \
+                self.mapping.transform_inverse(
+                    prob_map.copy(),
+                    interpolation='nearest')
 
         return warped_prob_map, include_rois, exclude_rois,\
             include_roi_tols, exclude_roi_tols

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -766,6 +766,9 @@ class Segmentation:
         tg = StatefulTractogram(tg.streamlines[possible_fibers],
                                 self.img,
                                 Space.VOX)
+        if self.return_idx:
+            out_idx = out_idx[possible_fibers]
+
         streamlines_in_bundles = streamlines_in_bundles[possible_fibers]
         min_dist_coords = min_dist_coords[possible_fibers]
         if self.roi_dist_tie_break:
@@ -775,8 +778,9 @@ class Segmentation:
 
         if self.save_intermediates is not None:
             os.makedirs(self.save_intermediates, exist_ok=True)
-            bc_path = op.join(self.save_intermediates, "bundle_choice.npy")
-            np.save(bc_path, bundle_choice)
+            bc_path = op.join(self.save_intermediates,
+                              "sls_bundle_assignment.npy")
+            np.save(bc_path, streamlines_in_bundles)
 
         # We do another round through, so that we can orient all the
         # streamlines within a bundle in the same orientation with respect to

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -772,7 +772,7 @@ def test_AFQ_data_waypoint():
     tract_profiles = pd.read_csv(tract_profile_fname)
 
     assert tract_profiles.select_dtypes(include=[np.number]).sum().sum() != 0
-    assert tract_profiles.shape == (300, 8)
+    assert tract_profiles.shape == (500, 8)
 
     myafq.export("indiv_bundles_figures")
     assert op.exists(op.join(
@@ -843,7 +843,7 @@ def test_AFQ_data_waypoint():
     # The tract profiles should already exist from the CLI Run:
     from_file = pd.read_csv(tract_profile_fname)
 
-    assert from_file.shape == (300, 8)
+    assert from_file.shape == (500, 8)
     assert_series_equal(tract_profiles['dti_fa'], from_file['dti_fa'])
 
     # Make sure the CLI did indeed generate these:

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -217,6 +217,49 @@ def test_clean_by_endpoints():
     npt.assert_array_equal(clean_idx, np.array([0, 2, 3]))
 
 
+def test_exclusion_ROI():
+    segmentation = seg.Segmentation(
+        filter_by_endpoints=False
+    )
+    slf_bundle = {
+        'SLF_L': {
+            'include': [
+                templates['SLF_roi1_L'],
+                templates['SLF_roi2_L']],
+            'cross_midline': None}}
+
+    # tractogram where 1 streamline goes through include ROIs only
+    # and the other goes through both include and exclude ROIs
+    slf_tg = StatefulTractogram(
+        np.asarray(
+            [
+                [[6, 50, 39], [28, 38, 61], [28, 61, 38]],
+                [[6, 50, 39], [28, 38, 62], [18, 41, 31]]
+            ]).astype(float),
+        hardi_img, Space.VOX)
+    fiber_groups = segmentation.segment(
+        slf_bundle,
+        slf_tg,
+        hardi_fdata,
+        hardi_fbval,
+        hardi_fbvec,
+        mapping=mapping,
+    )
+    npt.assert_equal(len(fiber_groups["SLF_L"]), 2)
+
+    slf_bundle['SLF_L']['exclude'] = [templates["SLFt_roi2_L"]]
+
+    fiber_groups = segmentation.segment(
+        slf_bundle,
+        slf_tg,
+        hardi_fdata,
+        hardi_fbval,
+        hardi_fbvec,
+        mapping=mapping,
+    )
+    npt.assert_equal(len(fiber_groups["SLF_L"]), 1)
+
+
 def test_segment_sampled_streamlines():
 
     # default segmentation

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -194,38 +194,27 @@ def test_clean_by_endpoints():
     atlas[4, 1, 1] = 3
     atlas[4, 1, 2] = 4
 
-    clean_sl, _ = seg.clean_by_endpoints(
-        sl, [1, 2], [3, 4], atlas=atlas)
-    npt.assert_equal(list(clean_sl), sl[:2])
-
-    clean_results, _ = seg.clean_by_endpoints(
-        sl, [1, 2], [3, 4], atlas=atlas)
-
-    clean_idx = []
-    clean_sl = []
-    for res in list(clean_results):
-        clean_sl.append(res[0])
-        clean_idx.append(res[1])
-    npt.assert_equal(list(clean_sl), sl[:2])
-    npt.assert_equal(clean_idx, np.array([0, 1]))
+    clean_idx = list(seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], atlas=atlas))
+    npt.assert_array_equal(clean_idx, np.array([0, 1]))
 
     # If tol=1, the third streamline also gets included
-    clean_sl, _ = seg.clean_by_endpoints(
-        sl, [1, 2], [3, 4], tol=1, atlas=atlas)
-    npt.assert_equal(list(clean_sl), sl[:3])
+    clean_idx = list(seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], tol=1, atlas=atlas))
+    npt.assert_array_equal(clean_idx, np.array([0, 1, 2]))
 
     # Provide the Nx3 array of indices instead.
     idx_start = np.array(np.where(atlas == 1)).T
     idx_end = np.array(np.where(atlas == 3)).T
 
-    clean_sl, _ = seg.clean_by_endpoints(
-        sl, idx_start, idx_end, atlas=atlas)
-    npt.assert_equal(list(clean_sl), np.array([sl[0]]))
+    clean_idx = list(seg.clean_by_endpoints(
+        sl, idx_start, idx_end, atlas=atlas))
+    npt.assert_array_equal(clean_idx, np.array([0]))
 
     # Sometimes no requirement for one side:
-    clean_sl, _ = seg.clean_by_endpoints(
-        sl, [1], None, atlas=atlas)
-    npt.assert_equal(list(clean_sl), [sl[0], sl[2], sl[3]])
+    clean_idx = list(seg.clean_by_endpoints(
+        sl, [1], None, atlas=atlas))
+    npt.assert_array_equal(clean_idx, np.array([0, 2, 3]))
 
 
 def test_segment_sampled_streamlines():

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -194,33 +194,37 @@ def test_clean_by_endpoints():
     atlas[4, 1, 1] = 3
     atlas[4, 1, 2] = 4
 
-    clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], atlas=atlas)
+    clean_sl, _ = seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:2])
 
-    clean_results = list(seg.clean_by_endpoints(sl, [1, 2], [3, 4],
-                                                atlas=atlas,
-                                                return_idx=True))
+    clean_results, _ = seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], atlas=atlas)
+
     clean_idx = []
     clean_sl = []
-    for res in clean_results:
+    for res in list(clean_results):
         clean_sl.append(res[0])
         clean_idx.append(res[1])
     npt.assert_equal(list(clean_sl), sl[:2])
     npt.assert_equal(clean_idx, np.array([0, 1]))
 
     # If tol=1, the third streamline also gets included
-    clean_sl = seg.clean_by_endpoints(sl, [1, 2], [3, 4], tol=1, atlas=atlas)
+    clean_sl, _ = seg.clean_by_endpoints(
+        sl, [1, 2], [3, 4], tol=1, atlas=atlas)
     npt.assert_equal(list(clean_sl), sl[:3])
 
     # Provide the Nx3 array of indices instead.
     idx_start = np.array(np.where(atlas == 1)).T
     idx_end = np.array(np.where(atlas == 3)).T
 
-    clean_sl = seg.clean_by_endpoints(sl, idx_start, idx_end, atlas=atlas)
+    clean_sl, _ = seg.clean_by_endpoints(
+        sl, idx_start, idx_end, atlas=atlas)
     npt.assert_equal(list(clean_sl), np.array([sl[0]]))
 
     # Sometimes no requirement for one side:
-    clean_sl = seg.clean_by_endpoints(sl, [1], None, atlas=atlas)
+    clean_sl, _ = seg.clean_by_endpoints(
+        sl, [1], None, atlas=atlas)
     npt.assert_equal(list(clean_sl), [sl[0], sl[2], sl[3]])
 
 

--- a/examples/plot_afq_api.py
+++ b/examples/plot_afq_api.py
@@ -12,6 +12,7 @@ import os.path as op
 import matplotlib.pyplot as plt
 import nibabel as nib
 import plotly
+import pandas as pd
 
 from AFQ.api.group import GroupAFQ
 import AFQ.data.fetch as afd
@@ -180,3 +181,19 @@ fig_files = myafq.export("tract_profile_plots")["01"]
 ##########################################################################
 # .. figure:: {{ fig_files[0] }}
 #
+
+##########################################################################
+# We can check the number of streamlines per bundle, to make sure
+# every bundle is found with a reasonable amount of streamlines.
+
+bundle_counts = pd.read_csv(myafq.export("sl_counts")["01"], index_col=[0])
+for ind in bundle_counts.index:
+    #  few streamlines are found for these bundles in this subject
+    if ind in ["FA", "FP"]:
+        threshold = 25
+    else:
+        threshold = 100
+    if bundle_counts["n_streamlines_clean"][ind] < threshold:
+        raise ValueError((
+            "Small number of streamlines found "
+            f"for bundle(s):\n{bundle_counts}"))


### PR DESCRIPTION
@arokem  this PR puts the endpoint segmentation before the tie breaking, and works. I also made some changes to the API of the clean endpoints function, and I label this as WIP because I have a few ideas about rewriting the segmentation module based on how we currently use it. 