### PR TITLE
[FIX] only calc subject registration images when necessary

### DIFF
--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -273,9 +273,17 @@ class ItkMap(Definition):
             "TransformParameters"])[9:]
         their_prealign[3, 3] = 1.0
         warp_f5.close()
-        return reg.read_mapping(
+        mapping = reg.read_mapping(
             their_disp, dwi,
             reg_template, prealign=their_prealign)
+
+        def transform(self, data, **kwargs):
+            raise NotImplementedError(
+                "ITK based mappings can currently"
+                + " only transform from template to subject space")
+
+        mapping.transform = transform
+        return mapping
 
 
 class GeneratedMapMixin(object):

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -204,10 +204,10 @@ def get_reg_subject(data_imap, bids_info, base_fname, dwi,
             "reg_subject must be a str, ImageDefinition, or Nifti1Image")
 
     filename_dict = {
-        "b0": data_imap["b0"],
-        "power_map": data_imap["pmap"],
-        "dti_fa_subject": data_imap["dti_fa"],
-        "subject_sls": data_imap["b0"],
+        "b0": "b0",
+        "power_map": "pmap",
+        "dti_fa_subject": "dti_fa",
+        "subject_sls": "b0",
     }
     bm = nib.load(data_imap["brain_mask"])
 
@@ -222,7 +222,7 @@ def get_reg_subject(data_imap, bids_info, base_fname, dwi,
             data_imap=data_imap)
     else:
         if reg_subject_spec in filename_dict:
-            reg_subject_spec = filename_dict[reg_subject_spec]
+            reg_subject_spec = data_imap[filename_dict[reg_subject_spec]]
         img = nib.load(reg_subject_spec)
     bm = bm.get_fdata().astype(bool)
     masked_data = img.get_fdata()


### PR DESCRIPTION
Fixes a few random things from what I have seen in NKI run. CSD APM calculated even though it is not used. b0_transform calculated even though our ITK map imported does not do subject->template transformation. Does not fix the ITK mapping problem though, as the template_xform also shows the mapping problem.