### PR TITLE
[FIX] correctly calculate min / max sl length, update step_size docs

### DIFF
--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -76,8 +76,8 @@ def _verbose_generate_tractogram(self):
             # move to the next streamline if only the seed position
             # and not return all
             len_sl = len(streamline)
-            if len_sl * self.step_size > self.min_length \
-                and len_sl * self.step_size < self.max_length \
+            if len_sl > self.min_length \
+                and len_sl < self.max_length \
                     and len_sl > 1:
                 if self.save_seeds:
                     yield streamline, s

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -76,8 +76,8 @@ def _verbose_generate_tractogram(self):
             # move to the next streamline if only the seed position
             # and not return all
             len_sl = len(streamline)
-            if len_sl > self.min_length * self.step_size\
-                and len_sl < self.max_length * self.step_size\
+            if len_sl * self.step_size > self.min_length \
+                and len_sl * self.step_size < self.max_length \
                     and len_sl > 1:
                 if self.save_seeds:
                     yield streamline, s

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -76,9 +76,7 @@ def _verbose_generate_tractogram(self):
             # move to the next streamline if only the seed position
             # and not return all
             len_sl = len(streamline)
-            if len_sl > self.min_length \
-                and len_sl < self.max_length \
-                    and len_sl > 1:
+            if len_sl > self.min_length:
                 if self.save_seeds:
                     yield streamline, s
                 else:

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -1055,7 +1055,7 @@ class Segmentation:
         return fiber_groups
 
 
-def clean_bundle(tg, n_points=100, clean_rounds=20, distance_threshold=3,
+def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=3,
                  length_threshold=4, min_sl=20, stat='mean',
                  return_idx=False):
     """
@@ -1071,7 +1071,7 @@ def clean_bundle(tg, n_points=100, clean_rounds=20, distance_threshold=3,
         Default: 100
     clean_rounds : int, optional.
         Number of rounds of cleaning based on the Mahalanobis distance from
-        the mean of extracted bundles. Default: 20
+        the mean of extracted bundles. Default: 5
     distance_threshold : float, optional.
         Threshold of cleaning based on the Mahalanobis distance (the units are
         standard deviations). Default: 3.

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -1055,7 +1055,7 @@ class Segmentation:
         return fiber_groups
 
 
-def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=5,
+def clean_bundle(tg, n_points=100, clean_rounds=20, distance_threshold=3,
                  length_threshold=4, min_sl=20, stat='mean',
                  return_idx=False):
     """
@@ -1071,10 +1071,10 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=5,
         Default: 100
     clean_rounds : int, optional.
         Number of rounds of cleaning based on the Mahalanobis distance from
-        the mean of extracted bundles. Default: 5
+        the mean of extracted bundles. Default: 20
     distance_threshold : float, optional.
         Threshold of cleaning based on the Mahalanobis distance (the units are
-        standard deviations). Default: 5.
+        standard deviations). Default: 3.
     length_threshold: float, optional
         Threshold for cleaning based on length (in standard deviations). Length
         of any streamline should not be *more* than this number of stdevs from

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -21,7 +21,7 @@ from AFQ._fixes import (VerboseLocalTracking, VerboseParticleFilteringTracking,
 def track(params_file, directions="prob", max_angle=30., sphere=None,
           seed_mask=None, seed_threshold=0, n_seeds=1, random_seeds=False,
           rng_seed=None, stop_mask=None, stop_threshold=0, step_size=0.5,
-          min_length=40, max_length=200, odf_model="CSD",
+          min_length=20, max_length=250, odf_model="CSD",
           tracker="local"):
     """
     Tractography
@@ -79,9 +79,9 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
     step_size : float, optional.
         The size of a step (in voxels) of tractography. Default: 0.5
     min_length: int, optional
-        The miminal length (mm) in a streamline. Default: 40
+        The miminal length (mm) in a streamline. Default: 20
     max_length: int, optional
-        The miminal length (mm) in a streamline. Default: 200
+        The miminal length (mm) in a streamline. Default: 250
     odf_model : str, optional
         One of {"DTI", "CSD", "DKI"}. Defaults to use "DTI"
     tracker : str, optional

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -116,8 +116,8 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
     # from mm to voxel units:
     R = affine[0:3, 0:3]
     vox_dim = np.mean(np.diag(np.linalg.cholesky(R.T.dot(R))))
-    min_length = min_length / vox_dim
-    max_length = max_length / vox_dim
+    min_length = (min_length / vox_dim) / step_size
+    max_length = (max_length / vox_dim) / step_size
 
     logger.info("Generating Seeds...")
     if isinstance(n_seeds, int):

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -77,7 +77,7 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
         Defaults to 0 (this means that if no stop_mask is passed,
         we will stop only at the edge of the image).
     step_size : float, optional.
-        The size (in mm) of a step of tractography. Default: 0.5
+        The size of a step (in voxels) of tractography. Default: 0.5
     min_length: int, optional
         The miminal length (mm) in a streamline. Default: 40
     max_length: int, optional
@@ -111,6 +111,13 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
     affine = params_img.affine
     odf_model = odf_model.upper()
     directions = directions.lower()
+
+    # We need to calculate the size of a voxel, so we can transform
+    # from mm to voxel units:
+    R = affine[0:3, 0:3]
+    vox_dim = np.mean(np.diag(np.linalg.cholesky(R.T.dot(R))))
+    min_length = min_length / vox_dim
+    max_length = max_length / vox_dim
 
     logger.info("Generating Seeds...")
     if isinstance(n_seeds, int):

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -116,8 +116,8 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
     # from mm to voxel units:
     R = affine[0:3, 0:3]
     vox_dim = np.mean(np.diag(np.linalg.cholesky(R.T.dot(R))))
-    min_length = (min_length / vox_dim) / step_size
-    max_length = (max_length / vox_dim) / step_size
+    min_length = int((min_length / vox_dim) / step_size)
+    max_length = int((max_length / vox_dim) / step_size)
 
     logger.info("Generating Seeds...")
     if isinstance(n_seeds, int):

--- a/examples/plot_afq_api.py
+++ b/examples/plot_afq_api.py
@@ -189,7 +189,7 @@ fig_files = myafq.export("tract_profile_plots")["01"]
 bundle_counts = pd.read_csv(myafq.export("sl_counts")["01"], index_col=[0])
 for ind in bundle_counts.index:
     #  few streamlines are found for these bundles in this subject
-    if ind == "FP":
+    if ind == "FP" or ind == "FA":
         threshold = 10  # smaller than default 20 mm ?
     else:
         threshold = 40

--- a/examples/plot_afq_api.py
+++ b/examples/plot_afq_api.py
@@ -192,7 +192,7 @@ for ind in bundle_counts.index:
     if ind == "FP":
         threshold = 10  # smaller than default 20 mm ?
     else:
-        threshold = 100
+        threshold = 40
     if bundle_counts["n_streamlines_clean"][ind] < threshold:
         raise ValueError((
             "Small number of streamlines found "

--- a/examples/plot_afq_api.py
+++ b/examples/plot_afq_api.py
@@ -189,8 +189,8 @@ fig_files = myafq.export("tract_profile_plots")["01"]
 bundle_counts = pd.read_csv(myafq.export("sl_counts")["01"], index_col=[0])
 for ind in bundle_counts.index:
     #  few streamlines are found for these bundles in this subject
-    if ind in ["FA", "FP"]:
-        threshold = 25
+    if ind == "FP":
+        threshold = 10  # smaller than default 20 mm ?
     else:
         threshold = 100
     if bundle_counts["n_streamlines_clean"][ind] < threshold:

--- a/examples/plot_optic_radiations.py
+++ b/examples/plot_optic_radiations.py
@@ -50,8 +50,9 @@ bundles = abd.BundleDict({
     }
 })
 
-# combine custom ROIs with default BundleDict ROIs
-bundles = bundles + abd.BundleDict()
+# To combine custom ROIs with default BundleDict ROIs,
+# run this line:
+#     bundles = bundles + abd.BundleDict()
 
 brain_mask_definition = LabelledImageFile(
     suffix="seg",


### PR DESCRIPTION
Previously, min_length, max_length, and step_size were all in voxel space units but we docs said they were in mm.  Now, min_length and max_length are input in mm and docs clarify that step_size is in voxel space units. Then, min and max length are converted to step size units. I think this makes the most sense.