### PR TITLE
[FIX] Updating DIPY tracking params

### DIFF
--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -21,7 +21,7 @@ from AFQ._fixes import (VerboseLocalTracking, VerboseParticleFilteringTracking,
 def track(params_file, directions="prob", max_angle=30., sphere=None,
           seed_mask=None, seed_threshold=0, n_seeds=1, random_seeds=False,
           rng_seed=None, stop_mask=None, stop_threshold=0, step_size=0.5,
-          min_length=20, max_length=250, odf_model="CSD",
+          min_length=20, max_length=300, odf_model="CSD",
           tracker="local"):
     """
     Tractography

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -21,7 +21,7 @@ from AFQ._fixes import (VerboseLocalTracking, VerboseParticleFilteringTracking,
 def track(params_file, directions="prob", max_angle=30., sphere=None,
           seed_mask=None, seed_threshold=0, n_seeds=1, random_seeds=False,
           rng_seed=None, stop_mask=None, stop_threshold=0, step_size=0.5,
-          min_length=20, max_length=300, odf_model="CSD",
+          min_length=50, max_length=250, odf_model="CSD",
           tracker="local"):
     """
     Tractography

--- a/AFQ/tractography.py
+++ b/AFQ/tractography.py
@@ -77,7 +77,7 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
         Defaults to 0 (this means that if no stop_mask is passed,
         we will stop only at the edge of the image).
     step_size : float, optional.
-        The size of a step (in voxels) of tractography. Default: 0.5
+        The size of a step (in mm) of tractography. Default: 0.5
     min_length: int, optional
         The miminal length (mm) in a streamline. Default: 20
     max_length: int, optional
@@ -114,10 +114,8 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
 
     # We need to calculate the size of a voxel, so we can transform
     # from mm to voxel units:
-    R = affine[0:3, 0:3]
-    vox_dim = np.mean(np.diag(np.linalg.cholesky(R.T.dot(R))))
-    min_length = int((min_length / vox_dim) / step_size)
-    max_length = int((max_length / vox_dim) / step_size)
+    min_length = int(min_length / step_size)
+    max_length = int(max_length / step_size)
 
     logger.info("Generating Seeds...")
     if isinstance(n_seeds, int):


### PR DESCRIPTION
I am still a little confused by what the parameters input to DIPY's tractography algorithm means in terms of units. For example, a max length of 250mm causes problems for many bundles in HBN, however that should be long enough for a typical brain? This was triggered by lowering of max length from 1000mm in recent PR. 