### PR TITLE
[FIX] put afq_metadata.toml in the correct spot

### DIFF
--- a/AFQ/utils/bin.py
+++ b/AFQ/utils/bin.py
@@ -291,14 +291,11 @@ def parse_config_run_afq(toml_file, default_arg_dict, to_call="export_all",
     default_arg_dict['pyAFQ']['version'] = __version__
     default_arg_dict['pyAFQ']['platform'] = platform.system()
 
-    afq_path = op.join(bids_path, 'derivatives', 'afq')
-    os.makedirs(afq_path, exist_ok=True)
+    myafq = GroupAFQ(bids_path, **kwargs)
 
-    afq_metadata_file = op.join(afq_path, 'afq_metadata.toml')
+    afq_metadata_file = op.join(myafq.afq_path, 'afq_metadata.toml')
     with open(afq_metadata_file, 'w') as ff:
         ff.write(dict_to_toml(default_arg_dict))
-
-    myafq = GroupAFQ(bids_path, **kwargs)
 
     # call user specified function:
     if to_call == "all":

--- a/examples/plot_afq_api.py
+++ b/examples/plot_afq_api.py
@@ -189,8 +189,8 @@ fig_files = myafq.export("tract_profile_plots")["01"]
 bundle_counts = pd.read_csv(myafq.export("sl_counts")["01"], index_col=[0])
 for ind in bundle_counts.index:
     #  few streamlines are found for these bundles in this subject
-    if ind == "FP" or ind == "FA":
-        threshold = 10  # smaller than default 20 mm ?
+    if ind == "FP" or ind == "FA" or "VOF" in ind:
+        threshold = 20
     else:
         threshold = 40
     if bundle_counts["n_streamlines_clean"][ind] < threshold:


### PR DESCRIPTION
If output_dir is set, afq_metadata.toml needs to be put there instead of derivatives/afq