### PR TITLE
[ENH] Allow pediatric bundledict and template to be accessed from config file.

### DIFF
--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -632,6 +632,9 @@ def get_bundle_dict(base_fname, dwi, segmentation_params,
             reg_template = afd.read_ukbb_fa_template(mask=use_brain_mask)
         elif img_l == "hcp_atlas":
             reg_template = afd.read_mni_template(mask=use_brain_mask)
+        elif img_l == "pediatric":
+            reg_template = afd.read_pediatric_templates()[
+                "UNCNeo-withCerebellum-for-babyAFQ"]
         else:
             reg_template = nib.load(reg_template_spec)
 

--- a/AFQ/utils/bin.py
+++ b/AFQ/utils/bin.py
@@ -2,13 +2,13 @@ import toml
 import datetime
 import platform
 import os.path as op
-import os
 
 from argparse import ArgumentParser
 from funcargparse import FuncArgParser
 
 from AFQ.definitions.image import *  # interprets masks loaded from toml
 from AFQ.definitions.mapping import *  # interprets mappings loaded from toml
+from AFQ.api.bundle_dict import *  # interprets bundle_dicts loaded from toml
 from AFQ.definitions.utils import Definition
 from AFQ.api.utils import kwargs_descriptors
 
@@ -78,13 +78,15 @@ def toml_to_val(t):
         return eval(t)
     elif isinstance(t, str) and t[0] == '{':
         return eval(t)  # interpret as dictionary
-    elif isinstance(t, str) and ("Image" in t or "Map" in t):
+    elif isinstance(t, str) and ("Image" in t or "Map" in t or "Dict" in t):
         try:
-            definition = eval(t)
+            definition_or_dict = eval(t)
         except NameError:
             return t
-        if isinstance(definition, Definition):
-            return definition
+        if isinstance(definition_or_dict, Definition):
+            return definition_or_dict
+        elif isinstance(definition_or_dict, BundleDict):
+            return definition_or_dict
         else:
             return t
     else:


### PR DESCRIPTION
Here is an example of such a config file:

```
[BIDS_PARAMS]
bids_path = "example_bids_subject"
preproc_pipeline = "vistasoft"

[DATA]
reg_template_spec = "pediatric"
reg_subject_spec = "b0"
bundle_info="PediatricBundleDict()"

[TRACTOGRAPHY_PARAMS]
import_tract = "{'suffix': 'tractography', 'scope': 'mrtrix'}"

[SEGMENTATION_PARAMS]
filter_by_endpoints = false

[CLEANING_PARAMS]
distance_threshold = 4
```