### PR TITLE
[FIX] Import tract docs

### DIFF
--- a/docs/source/usage/converter.rst
+++ b/docs/source/usage/converter.rst
@@ -1,17 +1,17 @@
 Tractography from other pipelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pyAFQ can use tractography from other pipelines. To tell pyAFQ to use
-tractography from another pipeline, use the custom_tractography_bids_filters
+tractography from another pipeline, use the import_tract
 argument in the AFQ.api objects or in the configuration file. This argument expects
 a dictionary of BIDS filters. pyAFQ will use these BIDS filters to find the
 tractography for each subject in each session.
-Here is an example custom_tractography_bids_filters::
-    custom_tractography_bids_filters = {'scope': 'qsiprep', 'suffix': 'tractography'}
+Here is an example import_tract::
+    import_tract = {'scope': 'qsiprep', 'suffix': 'tractography'}
 This would look for a file with the suffix 'tractography' inside of the
 'qsiprep' pipeline. The name of the pipeline (in this case, 'qsiprep') should be
 specified in its dataset_description.json.
 
-There is an example usage of custom_tractography_bids_filters with the
+There is an example usage of import_tract with the
 :class:`AFQ.api.group.GroupAFQ` object in the 'How pyAFQ uses BIDS' example in :ref:`examples`.
 
 

--- a/examples/plot_bids_layout.py
+++ b/examples/plot_bids_layout.py
@@ -217,7 +217,7 @@ bundle_info = [
 ##########################################################################
 # Now, we can define our GroupAFQ object, pointing to the derivatives of the
 # `'my_tractography'` pipeline as inputs. This is done by setting the
-# `custom_tractography_bids_filters` key-word argument. We pass the
+# `import_tract` key-word argument. We pass the
 # `bundle_info` defined above. We also point to the preprocessed
 # data that is in a `'dmriprep'` pipeline. Note that the pipeline name
 # is not necessarily the name of the folder it is in; the pipeline name is
@@ -236,7 +236,7 @@ my_afq = GroupAFQ(
     bids_path,
     preproc_pipeline='vistasoft',
     bundle_info=bundle_info,
-    custom_tractography_bids_filters={
+    import_tract={
         "suffix": "tractography",
         "scope": "my_tractography"
     },


### PR DESCRIPTION
Two things here:
1. Update docs regarding name change to import_tract for importing custom tractographies
2. Only run additional bundle recognition like endpoint filtering and orientation filtering if streamlines are found in the first place
