### PR TITLE
MAINT: pep517 => build.

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -11,19 +11,19 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.9
-    - name: Install pep517
+    - name: Install pypa/build
       run: >-
         python -m
         pip install
-        pep517
+        build
         --user
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m
-        pep517.build
-        --source
-        --binary
-        --out-dir dist/
+        build
+        --sdist
+        --wheel
+        --outdir dist/
         .
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
Apparently "pep517" is being replace by "build". 