### PR TITLE
BF: Calculate mean b0 instead of mean not-b0

### DIFF
--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -84,7 +84,7 @@ def b0(dwi, data, gtab, img):
     """
     full path to a nifti file containing the mean b0
     """
-    mean_b0 = np.mean(data[..., ~gtab.b0s_mask], -1)
+    mean_b0 = np.mean(data[..., gtab.b0s_mask], -1)
     mean_b0_img = nib.Nifti1Image(mean_b0, img.affine)
     meta = dict(b0_threshold=gtab.b0_threshold,
                 source=dwi)


### PR DESCRIPTION
Fixes #950