### PR TITLE
[WIP, ENH, FIX] Re-organize the mapping code and remove ITK support

### DIFF
--- a/AFQ/api/participant.py
+++ b/AFQ/api/participant.py
@@ -233,23 +233,22 @@ class ParticipantAFQ(object):
                     " to a filename and will be ignored."))
 
         for filename in os.listdir(self.output_dir):
-            if filename in exception_file_names:
-                continue
             full_path = os.path.join(self.output_dir, filename)
+            if (full_path in exception_file_names)\
+                    or (not full_path.startswith(self.export("base_fname")))\
+                    or filename.endswith("json"):
+                continue
             if os.path.isfile(full_path) or os.path.islink(full_path):
-                if not full_path.startswith(self.export("base_fname")):
-                    continue
-                if not filename.endswith("json"):
-                    sidecar_file = f'{drop_extension(full_path)}.json'
-                    if op.exists(sidecar_file):
-                        sidecar_info = read_json(sidecar_file)
-                        if "dependent" in sidecar_info\
-                            and sidecar_info["dependent"]\
-                                in dependent_on_list:
-                            os.system(f"{cmd} {full_path} {suffix}")
-                            os.system(f"{cmd} {sidecar_file} {suffix}")
-                    else:
+                sidecar_file = f'{drop_extension(full_path)}.json'
+                if op.exists(sidecar_file):
+                    sidecar_info = read_json(sidecar_file)
+                    if "dependent" in sidecar_info\
+                        and sidecar_info["dependent"]\
+                            in dependent_on_list:
                         os.system(f"{cmd} {full_path} {suffix}")
+                        os.system(f"{cmd} {sidecar_file} {suffix}")
+                else:
+                    os.system(f"{cmd} {full_path} {suffix}")
             elif os.path.isdir(full_path):
                 # other than ROIs, folders are dependent on everything
                 if dependent_on is None or filename != "ROIs":

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -794,13 +794,16 @@ def read_or_templates(as_img=True, resample_to=False):
     return template_dict
 
 
-stanford_hardi_tractography_remote_fnames = ["5325715", "5325718", "25289735"]
-stanford_hardi_tractography_hashes = ['6f4bdae702031a48d1cd3811e7a42ef9',
-                                      'f20854b4f710577c58bd01072cfb4de6',
+stanford_hardi_tractography_remote_fnames = [
+    "41836095", "41836125", "41836128", "25289735"]
+stanford_hardi_tractography_hashes = ['f20854b4f710577c58bd01072cfb4de6',
+                                      '8676e2ef04f57eaeaf78e4f5363387d9',
+                                      'e6aba38a995985ab186887f7172e3ca9',
                                       '294bfd1831861e8635eef8834ff18892']
 stanford_hardi_tractography_fnames = [
-    'mapping.nii.gz',
     'tractography_subsampled.trk',
+    'mapping_backward.nii.gz',
+    'mapping_forward.nii.gz',
     'full_segmented_cleaned_tractography.trk']
 
 fetch_stanford_hardi_tractography = _make_reusable_fetcher(
@@ -819,12 +822,16 @@ def read_stanford_hardi_tractography():
     """
     Reads a minimal tractography from the Stanford dataset.
     """
-    files, folder = fetch_stanford_hardi_tractography()
+    fetch_stanford_hardi_tractography()
     files_dict = {}
-    files_dict['mapping.nii.gz'] = nib.load(
+    files_dict['mapping_forward.nii.gz'] = nib.load(
         op.join(afq_home,
                 'stanford_hardi_tractography',
-                'mapping.nii.gz'))
+                'mapping_forward.nii.gz'))
+    files_dict['mapping_backward.nii.gz'] = nib.load(
+        op.join(afq_home,
+                'stanford_hardi_tractography',
+                'mapping_backward.nii.gz'))
 
     # We need the original data as reference
     dwi_img, gtab = dpd.read_stanford_hardi()

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -294,10 +294,6 @@ class ConformedITKMapping():
         self.templ_ref = templ_ref
 
     def transform_inverse(self, data, **kwargs):
-        from AFQ.data.fetch import read_mni_template
-        data = resample(
-            read_mni_template(),
-            self.templ_ref).get_fdata()
         data = self.tx.apply_to_image(
             ants.from_numpy(data), **kwargs).numpy()
         return resample(

--- a/AFQ/definitions/mapping.py
+++ b/AFQ/definitions/mapping.py
@@ -12,7 +12,6 @@ from AFQ.tasks.utils import get_fname
 
 from dipy.align.imaffine import AffineMap
 from dipy.align.imwarp import DiffeomorphicMap
-from dipy.align import resample
 
 try:
     from fsl.data.image import Image
@@ -21,12 +20,6 @@ try:
     has_fslpy = True
 except ModuleNotFoundError:
     has_fslpy = False
-
-try:
-    import ants
-    has_antspyx = True
-except ModuleNotFoundError:
-    has_antspyx = False
 
 __all__ = ["FnirtMap", "SynMap", "SlrMap", "AffMap"]
 

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -102,7 +102,7 @@ def mapping(base_fname, dwi, reg_subject, data_imap, bids_info,
             bids_info["subject"],
             bids_info["session"])
     return mapping_definition.get_for_subses(
-        base_fname, dwi, bids_info, reg_subject, reg_template)
+        base_fname, data_imap["b0"], bids_info, reg_subject, reg_template)
 
 
 @pimms.calc("mapping")
@@ -152,7 +152,7 @@ def sls_mapping(base_fname, dwi, reg_subject, data_imap, bids_info,
         atlas_fname,
         'same', bbox_valid_check=False)
     return mapping_definition.get_for_subses(
-        base_fname, dwi, bids_info, reg_subject, reg_template,
+        base_fname, data_imap["b0"], bids_info, reg_subject, reg_template,
         subject_sls=tg.streamlines,
         template_sls=hcp_atlas.streamlines)
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -657,6 +657,7 @@ def test_AFQ_custom_subject_reg():
             suffix="customb0",
             filters={"scope": "vistasoft"}))
     myafq.export("rois")
+    raise ValueError()
 
 
 # Requires large download

--- a/AFQ/tests/test_registration.py
+++ b/AFQ/tests/test_registration.py
@@ -67,11 +67,16 @@ def test_slr_registration():
         warped_moving = mapping.transform(subset_b0)
 
         npt.assert_equal(warped_moving.shape, subset_t2.shape)
-        mapping_fname = op.join(tmpdir, 'mapping.npy')
-        write_mapping(mapping, mapping_fname)
+        mapping_fname = op.join(tmpdir, 'mapping_forward.npy')
+        mapping_back_fname = op.join(tmpdir, 'mapping_backward.npy')
+        write_mapping(
+            mapping,
+            subset_b0_img,
+            subset_t2_img,
+            mapping_fname,
+            mapping_back_fname)
         file_mapping = read_mapping(mapping_fname,
-                                    subset_b0_img,
-                                    subset_t2_img)
+                                    mapping_back_fname)
 
         # Test that it has the same effect on the data:
         warped_from_file = file_mapping.transform(subset_b0)

--- a/AFQ/tests/test_segmentation.py
+++ b/AFQ/tests/test_segmentation.py
@@ -24,9 +24,8 @@ hardi_fbval = op.join(hardi_dir, "HARDI150.bval")
 hardi_fbvec = op.join(hardi_dir, "HARDI150.bvec")
 file_dict = afd.read_stanford_hardi_tractography()
 mapping = reg.read_mapping(
-    file_dict['mapping.nii.gz'],
-    hardi_img,
-    afd.read_mni_template())
+    file_dict["mapping_forward.nii.gz"],
+    file_dict["mapping_backward.nii.gz"])
 streamlines = file_dict['tractography_subsampled.trk']
 tg = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
 tg.to_vox()
@@ -275,11 +274,11 @@ def test_exclusion_ROI():
         np.asarray(
             [
                 [
-                    [8, 53, 39], [8, 50, 39], [8, 45, 39],
+                    [8, 52, 44], [8, 50, 39], [8, 45, 39],
                     [30, 41, 61], [28, 61, 38]],
                 [
-                    [8, 53, 39], [8, 50, 39], [8, 45, 39],
-                    [30, 41, 62], [20, 44, 34]]
+                    [8, 52, 44], [8, 50, 39], [8, 45, 39],
+                    [30, 41, 62], [14, 34, 38]]
             ]).astype(float),
         hardi_img, Space.VOX)
     fiber_groups = segmentation.segment(

--- a/AFQ/viz/utils.py
+++ b/AFQ/viz/utils.py
@@ -309,9 +309,12 @@ def prepare_roi(roi, affine_or_mapping, static_img,
         The ROI information.
         If str, ROI will be loaded using the str as a path.
 
-    affine_or_mapping : ndarray, Nifti1Image, or str
+    affine_or_mapping : ndarray or tuple
        An affine transformation or mapping to apply to the ROI before
-       visualization. Default: no transform.
+       visualization. If mapping, it should be a tuple of filepaths
+       or nifti images representing the forward and backward
+       mappings.
+       Default: no transform.
 
     static_img: str or Nifti1Image
         Template to resample roi to.
@@ -347,16 +350,14 @@ def prepare_roi(roi, affine_or_mapping, static_img,
                            static_affine).get_fdata()
         else:
             # Assume it is  a mapping:
-            if (isinstance(affine_or_mapping, str)
-                    or isinstance(affine_or_mapping, nib.Nifti1Image)):
+            if isinstance(affine_or_mapping, tuple):
                 if reg_template is None or static_img is None:
                     raise ValueError(
                         "If using a mapping to transform an ROI, need to ",
                         "also specify all of the following inputs: ",
                         "`reg_template`, `static_img`")
-                affine_or_mapping = reg.read_mapping(affine_or_mapping,
-                                                     static_img,
-                                                     reg_template)
+                affine_or_mapping = reg.read_mapping(affine_or_mapping[0],
+                                                     affine_or_mapping[1])
 
             roi = auv.transform_inverse_roi(
                 roi,

--- a/docs/source/howto/docker.rst
+++ b/docs/source/howto/docker.rst
@@ -6,7 +6,7 @@ Everytime a new commit is made to master the
 a new image is pushed to the
 `NRDG github <https://github.com/orgs/nrdg/packages/container/package/pyafq>`_.
 This image contains an installation of the latest version of
-pyAFQ with fslpy and h5py. This image also contains an entrypoint, and can be
+pyAFQ with fslpy and antspyx. This image also contains an entrypoint, and can be
 run with::
     docker run -v bids_dir:/bids_dir:rw ghcr.io/nrdg/pyafq bids_dir/config.toml
 More information on config.toml can be found under "The pyAFQ configuration file".

--- a/docs/source/howto/docker.rst
+++ b/docs/source/howto/docker.rst
@@ -6,7 +6,7 @@ Everytime a new commit is made to master the
 a new image is pushed to the
 `NRDG github <https://github.com/orgs/nrdg/packages/container/package/pyafq>`_.
 This image contains an installation of the latest version of
-pyAFQ with fslpy and antspyx. This image also contains an entrypoint, and can be
+pyAFQ with fslpy. This image also contains an entrypoint, and can be
 run with::
     docker run -v bids_dir:/bids_dir:rw ghcr.io/nrdg/pyafq bids_dir/config.toml
 More information on config.toml can be found under "The pyAFQ configuration file".

--- a/examples/howto_examples/plot_afq_fwdti.py
+++ b/examples/howto_examples/plot_afq_fwdti.py
@@ -19,7 +19,6 @@ import nibabel as nib
 from AFQ.api.group import GroupAFQ
 import AFQ.data.fetch as afd
 
-from AFQ.definitions.mapping import ItkMap
 from AFQ.definitions.image import ImageFile, RoiImage
 import AFQ.api.bundle_dict as abd
 
@@ -59,12 +58,6 @@ brain_mask_definition = ImageFile(
              'space': 'T1w',
              'scope': 'qsiprep'})
 
-mapping_definition = ItkMap(
-    warp_suffix='xfm',
-    warp_filters={'from': 'MNI152NLin2009cAsym',
-                  'to': 'T1w',
-                  'scope': 'qsiprep'})
-
 
 bundle_names = ["ARC_L", "ARC_R"]
 bundle_dict = abd.BundleDict(bundle_names)
@@ -79,7 +72,6 @@ myafq = GroupAFQ(
         "random_seeds": True,
         "seed_mask": RoiImage(use_waypoints=True, use_endpoints=True),
     },
-    mapping_definition=mapping_definition,
     brain_mask_definition=brain_mask_definition,
     scalars=["fwdti_fa", "fwdti_md", "fwdti_fwf", "dti_fa", "dti_md"])
 

--- a/examples/howto_examples/plot_callosal_tract_profile.py
+++ b/examples/howto_examples/plot_callosal_tract_profile.py
@@ -160,6 +160,8 @@ show_anatomical_slices(FA_data, 'Fractional Anisotropy (FA)')
 
 print("Registering to template...")
 MNI_T2_img = afd.read_mni_template()
+mapping_forward_fname = op.join(working_dir, 'mapping_forward.nii.gz')
+mapping_backward_fname = op.join(working_dir, 'mapping_backward.nii.gz')
 
 if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     import dipy.core.gradients as dpg
@@ -176,12 +178,17 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     # prealignment
     warped_hardi, mapping = reg.syn_register_dwi(hardi_fdata, gtab,
                                                  prealign=prealign)
-    reg.write_mapping(mapping, op.join(working_dir, 'mapping.nii.gz'))
+    reg.write_mapping(
+        mapping,
+        img,
+        MNI_T2_img,
+        mapping_forward_fname,
+        mapping_backward_fname)
 else:
-    mapping = reg.read_mapping(op.join(working_dir, 'mapping.nii.gz'),
-                               img, MNI_T2_img)
+    mapping = reg.read_mapping(mapping_forward_fname,
+                               mapping_backward_fname)
 
-mapping_img = nib.load(op.join(working_dir, 'mapping.nii.gz'))
+mapping_img = nib.load(mapping_forward_fname)
 mapping_img_data = mapping_img.get_fdata()
 
 # Working with diffeomorphic map data

--- a/examples/howto_examples/plot_recobundles.py
+++ b/examples/howto_examples/plot_recobundles.py
@@ -60,6 +60,8 @@ FA_data = FA_img.get_fdata()
 
 print("Registering to template...")
 MNI_T2_img = afd.read_mni_template()
+mapping_forward_fname = op.join(working_dir, 'mapping_forward.nii.gz')
+mapping_backward_fname = op.join(working_dir, 'mapping_backward.nii.gz')
 
 if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     import dipy.core.gradients as dpg
@@ -76,10 +78,15 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     # prealignment
     warped_hardi, mapping = reg.syn_register_dwi(hardi_fdata, gtab,
                                                  prealign=prealign)
-    reg.write_mapping(mapping, op.join(working_dir, 'mapping.nii.gz'))
+    reg.write_mapping(
+        mapping,
+        img,
+        MNI_T2_img,
+        mapping_forward_fname,
+        mapping_backward_fname)
 else:
-    mapping = reg.read_mapping(op.join(working_dir, 'mapping.nii.gz'),
-                               img, MNI_T2_img)
+    mapping = reg.read_mapping(mapping_forward_fname,
+                               mapping_backward_fname)
 
 
 bundle_names = [

--- a/examples/tutorial_examples/plot_tract_profile.py
+++ b/examples/tutorial_examples/plot_tract_profile.py
@@ -85,6 +85,8 @@ FA_data = FA_img.get_fdata()
 
 print("Registering to template...")
 MNI_T2_img = afd.read_mni_template()
+mapping_forward_fname = op.join(working_dir, 'mapping_forward.nii.gz')
+mapping_backward_fname = op.join(working_dir, 'mapping_backward.nii.gz')
 
 if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     import dipy.core.gradients as dpg
@@ -101,10 +103,15 @@ if not op.exists(op.join(working_dir, 'mapping.nii.gz')):
     # prealignment
     warped_hardi, mapping = reg.syn_register_dwi(hardi_fdata, gtab,
                                                  prealign=prealign)
-    reg.write_mapping(mapping, op.join(working_dir, 'mapping.nii.gz'))
+    reg.write_mapping(
+        mapping,
+        img,
+        MNI_T2_img,
+        mapping_forward_fname,
+        mapping_backward_fname)
 else:
-    mapping = reg.read_mapping(op.join(working_dir, 'mapping.nii.gz'),
-                               img, MNI_T2_img)
+    mapping = reg.read_mapping(mapping_forward_fname,
+                               mapping_backward_fname)
 
 
 ##########################################################################

--- a/pyafq_docker/Dockerfile
+++ b/pyafq_docker/Dockerfile
@@ -10,6 +10,6 @@ ARG COMMIT
 # Install pyAFQ
 RUN pip install --no-cache-dir git+https://github.com/yeatmanlab/pyAFQ.git@${COMMIT}
 RUN pip install fslpy
-RUN pip install h5py
+RUN pip install antspyx
 
 ENTRYPOINT ["pyAFQ"]

--- a/pyafq_docker/Dockerfile
+++ b/pyafq_docker/Dockerfile
@@ -10,6 +10,5 @@ ARG COMMIT
 # Install pyAFQ
 RUN pip install --no-cache-dir git+https://github.com/yeatmanlab/pyAFQ.git@${COMMIT}
 RUN pip install fslpy
-RUN pip install antspyx
 
 ENTRYPOINT ["pyAFQ"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,9 @@ fury =
     ipython>=7.13.0,<=7.20.0
 fsl =
     fslpy
-itk =
-    h5py
+ants =
+    statsmodels==0.13.1
+    antspyx
 afqbrowser =
     AFQ-Browser>=0.3
 plot =
@@ -91,6 +92,6 @@ all =
     %(dev)s
     %(fury)s
     %(fsl)s
-    %(itk)s
+    %(ants)s
     %(afqbrowser)s
     %(plot)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,9 +79,6 @@ fury =
     ipython>=7.13.0,<=7.20.0
 fsl =
     fslpy
-ants =
-    statsmodels==0.13.1
-    antspyx
 afqbrowser =
     AFQ-Browser>=0.3
 plot =
@@ -92,6 +89,5 @@ all =
     %(dev)s
     %(fury)s
     %(fsl)s
-    %(ants)s
     %(afqbrowser)s
     %(plot)s


### PR DESCRIPTION
This PR features:

- Change to saving mappings as forward and backwards replacement fields. This is more general and easier (at least for me) to understand than saving as an image with forward and backward resampled to the same dimensions with affine in a separate numpy file.
- Fixes the "exceptions" argument for the clobber command
- Removes ITK class for now, as it only works in certain cases (not with current versions of qsiprep) (hopefully will be solved in future with nitransforms)