### PR TITLE
[ENH] Much faster mahal cleaning

### DIFF
--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -13,6 +13,7 @@ import math
 
 from dipy.reconst.gqi import squared_radial_component
 from dipy.data import default_sphere
+from dipy.tracking.streamline import set_number_of_points
 from scipy.linalg import blas
 
 
@@ -230,35 +231,88 @@ def tensor_odf(evals, evecs, sphere, num_batches=100):
     return odf
 
 
-def fast_mahal(sls, stat):
+def gaussian_weights(bundle, n_points=100, return_mahalnobis=False,
+                     stat=np.mean):
     """
-    Calculate an average streamline using stat,
-    then the Mahalonobis distance between every
-    streamline and that average streamline.
+    Calculate weights for each streamline/node in a bundle, based on a
+    Mahalanobis distance from the core the bundle, at that node (mean, per
+    default).
 
     Parameters
     ----------
-    sls : array-like of shape (n_sls, n_nodes, 3)
-        Streamlines
-    stat : function
-        function to calculate average (could be np.mean)
+    bundle : Streamlines
+        The streamlines to weight.
+    n_points : int, optional
+        The number of points to resample to. *If the `bundle` is an array,
+        this input is ignored*. Default: 100.
+    return_mahalanobis : bool, optional
+        Whether to return the Mahalanobis distance instead of the weights.
+        Default: False.
+    stat : callable, optional.
+        The statistic used to calculate the central tendency of streamlines in
+        each node. Can be one of {`np.mean`, `np.median`} or other functions
+        that have similar API. Default: `np.mean`
 
     Returns
     -------
-    nbrs : array-like of shape (n_sls, n_nodes)
-        Mahalonobis distance between each streamline and
-        the reference streamline.
+    w : array of shape (n_streamlines, n_points)
+        Weights for each node in each streamline, calculated as its relative
+        inverse of the Mahalanobis distance, relative to the distribution of
+        coordinates at that node position across streamlines.
+
     """
+
+    # Resample to same length for each streamline
+    # if necessary
+    resample = False
+    if isinstance(bundle, np.ndarray):
+        if len(bundle.shape) > 2:
+            if bundle.shape[1] != n_points:
+                sls = bundle.tolist()
+                sls = [np.asarray(item) for item in sls]
+                resample = True
+    else:
+        resample = True
+    if resample:
+        sls = set_number_of_points(bundle, n_points)
+    else:
+        sls = bundle
+
+    # If there's only one fiber here, it gets the entire weighting:
+    if len(bundle) == 1:
+        if return_mahalnobis:
+            return np.array([np.nan])
+        else:
+            return np.array([1])
+
     n_sls, n_nodes, n_dim = sls.shape
-    res = np.zeros((n_sls, n_nodes))
+    weights = np.zeros((n_sls, n_nodes))
     diff = stat(sls, axis=0) - sls
     for i in range(n_nodes):
+        # This should come back as a 3D covariance matrix with the spatial
+        # variance covariance of this node across the different streamlines,
+        # reorganized as an upper diagonal matrix for expected Mahalanobis
         v_inv = np.triu(np.cov(sls[:, i, :].T, ddof=0))
+
+        # calculate Mahalanobis for node in every fiber
         if np.linalg.matrix_rank(v_inv) == n_dim:
             v_inv = np.linalg.inv(v_inv)
 
             dist = (diff[:, i, :] @ v_inv) * diff[:, i, :]
-            res[:, i] = np.sqrt(np.sum(dist, axis=1))
+            weights[:, i] = np.sqrt(np.sum(dist, axis=1))
+
+        # In the special case where all the streamlines have the exact same
+        # coordinate in this node, the covariance matrix is all zeros, so
+        # we can't calculate the Mahalanobis distance, we will instead give
+        # each streamline an identical weight, equal to the number of
+        # streamlines:
         else:
-            res[:, i] = 0
-    return res
+            weights[:, i] = 0
+    if return_mahalnobis:
+        return weights
+
+    # weighting is inverse to the distance (the further you are, the less you
+    # should be weighted)
+    weights = 1 / weights
+    # Normalize before returning, so that the weights in each node sum to 1:
+    return weights / np.sum(weights, 0)

--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -228,3 +228,28 @@ def tensor_odf(evals, evecs, sphere, num_batches=100):
     odf = np.zeros((evals.shape[:3] + (sphere.vertices.shape[0],)))
     odf[mask] = proj_norm.T
     return odf
+
+
+def fast_mahal(sls, stat):
+    """
+    Calculate an average streamline using stat,
+    then the Mahalonobis distance between every
+    streamline and that average streamline.
+
+    Parameters
+    ----------
+    sls : array-like of shape (n_sls, n_nodes, 3)
+        Streamlines
+    stat : function
+        function to calculate average (could be np.mean)
+
+    Returns
+    -------
+    nbrs : array-like of shape (n_sls, n_nodes)
+        Mahalonobis distance between each streamline and
+        the reference streamline.
+    """
+    ref_sl = stat(sls, axis=0)
+    v_inv = np.linalg.inv(np.cov(sls.reshape(-1, 3).T, ddof=0))
+    diff = ref_sl - sls
+    return np.sqrt(np.sum((diff @ v_inv) * diff, axis=2))

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -23,7 +23,7 @@ import AFQ.data.fetch as afd
 from AFQ.data.utils import BUNDLE_RECO_2_AFQ
 from AFQ.api.bundle_dict import BundleDict
 from AFQ.definitions.mapping import ConformedFnirtMapping
-from AFQ._fixes import fast_mahal
+from AFQ._fixes import gaussian_weights
 
 __all__ = ["Segmentation", "clean_bundle", "clean_by_endpoints"]
 
@@ -1174,7 +1174,9 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=3,
     rounds_elapsed = 0
     while rounds_elapsed < clean_rounds and len(streamlines) > min_sl:
         # This calculates the Mahalanobis for each streamline/node:
-        m_dist = fast_mahal(fgarray, stat)
+        m_dist = gaussian_weights(
+            fgarray, return_mahalnobis=True,
+            n_points=n_points, stat=stat)
         logger.debug(f"Shape of fgarray: {np.asarray(fgarray).shape}")
         logger.debug(f"Shape of m_dist: {m_dist.shape}")
         logger.debug(f"Maximum m_dist: {np.max(m_dist)}")

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -439,7 +439,7 @@ class Segmentation:
         self.fbval = fbval
         self.fbvec = fbvec
 
-    def cross_streamlines(self, tg=None, template=None, low_coord=10):
+    def cross_streamlines(self, tg=None, template=None):
         """
         Classify the streamlines by whether they cross the midline.
         Creates a crosses attribute which is an array of booleans. Each boolean
@@ -462,14 +462,9 @@ class Segmentation:
         zero_coord = np.dot(np.linalg.inv(template_affine),
                             np.array([0, 0, 0, 1]))
 
-        self.crosses = np.zeros(len(tg), dtype=bool)
-        # already_split = 0
-        for sl_idx, sl in enumerate(tg.streamlines):
-            if np.any(sl[:, 0] > zero_coord[0]) and \
-                    np.any(sl[:, 0] < zero_coord[0]):
-                self.crosses[sl_idx] = True
-            else:
-                self.crosses[sl_idx] = False
+        self.crosses = np.logical_and(
+            np.any(tg.streamlines[:, :, 0] > zero_coord[0], axis=1),
+            np.any(tg.streamlines[:, :, 0] < zero_coord[0], axis=1))
 
     def _return_empty(self, bundle):
         """

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -23,6 +23,7 @@ import AFQ.data.fetch as afd
 from AFQ.data.utils import BUNDLE_RECO_2_AFQ
 from AFQ.api.bundle_dict import BundleDict
 from AFQ.definitions.mapping import ConformedFnirtMapping
+from AFQ._fixes import fast_mahal
 
 __all__ = ["Segmentation", "clean_bundle", "clean_by_endpoints"]
 
@@ -1171,7 +1172,7 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=3,
             return tg
 
     # Resample once up-front:
-    fgarray = _resample_tg(streamlines, n_points)
+    fgarray = np.asarray(_resample_tg(streamlines, n_points))
 
     # Keep this around, so you can use it for indexing at the very end:
     idx = np.arange(len(fgarray))
@@ -1181,7 +1182,7 @@ def clean_bundle(tg, n_points=100, clean_rounds=5, distance_threshold=3,
     rounds_elapsed = 0
     while rounds_elapsed < clean_rounds and len(streamlines) > min_sl:
         # This calculates the Mahalanobis for each streamline/node:
-        m_dist = gaussian_weights(fgarray, return_mahalnobis=True, stat=stat)
+        m_dist = fast_mahal(fgarray, stat)
         logger.debug(f"Shape of fgarray: {np.asarray(fgarray).shape}")
         logger.debug(f"Shape of m_dist: {m_dist.shape}")
         logger.debug(f"Maximum m_dist: {np.max(m_dist)}")

--- a/AFQ/tests/test_fixes.py
+++ b/AFQ/tests/test_fixes.py
@@ -11,10 +11,12 @@ import dipy.core.gradients as dpg
 from dipy.data import default_sphere
 from dipy.reconst.gqi import GeneralizedQSamplingModel
 from dipy.tracking.streamline import set_number_of_points
+
+from AFQ._fixes import gaussian_weights as gaussian_weights_fast
 from dipy.stats.analysis import gaussian_weights
 
 from AFQ.utils.testing import make_dki_data
-from AFQ._fixes import gwi_odf, fast_mahal
+from AFQ._fixes import gwi_odf
 
 
 def test_GQI_fix():
@@ -55,13 +57,16 @@ def test_mahal_fix():
         [0.      , 0.      , 0.      , 0.687989, 0.358011],
         [0.      , 0.      , 0.      , 1.414214, 1.347267]])
     npt.assert_array_almost_equal(
-        fast_mahal(sls_array, np.mean), results)
-    
+        gaussian_weights_fast(
+            sls_array, n_points=5,
+            return_mahalnobis=True, stat=np.mean), results)
+
     sls = Streamlines(sls)
     dipy_res = gaussian_weights(
         sls, n_points=5, return_mahalnobis=True, stat=np.mean)
     sls = np.asarray(set_number_of_points(sls, 5))
-    our_res = fast_mahal(sls, np.mean)
+    our_res = gaussian_weights_fast(
+        sls, n_points=5, return_mahalnobis=True, stat=np.mean)
 
     # note the current dipy version
     # handles 0 variance differently than this implementation

--- a/AFQ/tests/test_fixes.py
+++ b/AFQ/tests/test_fixes.py
@@ -1,5 +1,6 @@
 import nibabel.tmpdirs as nbtmp
 import nibabel as nib
+import numpy as np
 
 import os.path as op
 import numpy.testing as npt
@@ -9,7 +10,7 @@ from dipy.data import default_sphere
 from dipy.reconst.gqi import GeneralizedQSamplingModel
 
 from AFQ.utils.testing import make_dki_data
-from AFQ._fixes import gwi_odf
+from AFQ._fixes import gwi_odf, fast_mahal
 
 
 def test_GQI_fix():
@@ -30,3 +31,24 @@ def test_GQI_fix():
         odf_theirs = gqmodel.fit(data).odf(default_sphere)
 
         npt.assert_array_almost_equal(odf_ours, odf_theirs)
+
+
+def test_mahal_fix():
+    sls = np.asarray(
+            [
+                [
+                    [8, 53, 39], [8, 50, 39], [8, 45, 39],
+                    [30, 41, 61], [28, 61, 38]],
+                [
+                    [8, 53, 39], [8, 50, 39], [8, 45, 39],
+                    [30, 41, 62], [20, 44, 34]],
+                [
+                    [8, 53, 39], [8, 50, 39], [8, 45, 39],
+                    [50, 67, 88], [10, 10, 20]]
+            ]).astype(float)
+    results = np.asarray([
+        [0., 0., 0., 0.78747824, 2.1825342],
+        [0., 0., 0., 0.79234941, 0.49218687],
+        [0., 0., 0., 1.57406803, 2.54889886]])
+    npt.assert_array_almost_equal(
+        fast_mahal(sls, np.mean), results)


### PR DESCRIPTION
It my case, it reduced the clean time from around 15 minutes to around 4 seconds (225x speedup).
We do this by using numpy functions instead of for loops. In _fixes for now, but can be moved to dipy later.