### PR TITLE
RF: Update call to seaborn plotting.

### DIFF
--- a/AFQ/viz/plot.py
+++ b/AFQ/viz/plot.py
@@ -165,7 +165,9 @@ class BrainAxes():
         sns.lineplot(
             x=x, y=y,
             data=data,
-            estimator='mean', ci=95, n_boot=n_boot,
+            estimator='mean',
+            errorbar=('ci', 95),
+            n_boot=n_boot,
             legend=False, ax=ax, alpha=alpha,
             style=[True] * len(data.index), **lineplot_kwargs_mean)
 


### PR DESCRIPTION
Should get rid of the following warning:

```
/Users/arokem/source/pyAFQ/AFQ/viz/plot.py:165: FutureWarning:

The `ci` parameter is deprecated. Use `errorbar=('ci', 95)` for the same effect.

```