### PR TITLE
[ENH] make source field relative in json sidecars

### DIFF
--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -787,7 +787,7 @@ class BundleDict(MutableMapping):
         if self.seg_algo == "afq":
             if "Forceps Major" in self.bundle_names\
                     and "Callosum Occipital" in self.bundle_names:
-                self.logger.warning((
+                self.logger.info((
                     "Forceps Major and Callosum Occipital bundles"
                     " are co-located, and AFQ"
                     " assigns each streamline to only one bundle."
@@ -795,7 +795,7 @@ class BundleDict(MutableMapping):
                 self.bundle_names.remove("Forceps Major")
             if "Forceps Minor" in self.bundle_names\
                     and "Callosum Orbital" in self.bundle_names:
-                self.logger.warning((
+                self.logger.info((
                     "Forceps Minor and Callosum Orbital bundles"
                     " are co-located, and AFQ"
                     " assigns each streamline to only one bundle."
@@ -803,7 +803,7 @@ class BundleDict(MutableMapping):
                 self.bundle_names.remove("Forceps Minor")
             if "Forceps Minor" in self.bundle_names\
                     and "Callosum Anterior Frontal" in self.bundle_names:
-                self.logger.warning((
+                self.logger.info((
                     "Forceps Minor and Callosum Anterior Frontal bundles"
                     " are co-located, and AFQ"
                     " assigns each streamline to only one bundle."

--- a/AFQ/api/group.py
+++ b/AFQ/api/group.py
@@ -303,7 +303,7 @@ class GroupAFQ(object):
                     dwi_data_file,
                     bval_file, bvec_file,
                     results_dir,
-                    bids_info={
+                    _bids_info={
                         "bids_layout": bids_layout,
                         "subject": subject,
                         "session": session},

--- a/AFQ/api/participant.py
+++ b/AFQ/api/participant.py
@@ -34,7 +34,7 @@ class ParticipantAFQ(object):
                  dwi_data_file,
                  bval_file, bvec_file,
                  output_dir,
-                 bids_info=None,
+                 _bids_info=None,
                  **kwargs):
         """
         Initialize a ParticipantAFQ object from a BIDS dataset.
@@ -49,8 +49,9 @@ class ParticipantAFQ(object):
             Path to bvec file.
         output_dir : str
             Path to output directory.
-        bids_info : dict or None, optional
-            This is used by GroupAFQ to provide information about
+        _bids_info : dict or None, optional
+            This should be left as None in most cases. It
+            is used by GroupAFQ to provide information about
             the BIDS layout to each participant.
         kwargs : additional optional parameters
             You can set additional parameters for any step
@@ -102,7 +103,7 @@ class ParticipantAFQ(object):
             bval=bval_file,
             bvec=bvec_file,
             results_dir=output_dir,
-            bids_info=bids_info,
+            bids_info=_bids_info,
             base_fname=get_base_fname(output_dir, dwi_data_file),
             **kwargs)
         self.make_workflow()

--- a/AFQ/tasks/decorators.py
+++ b/AFQ/tasks/decorators.py
@@ -116,7 +116,7 @@ def as_file(suffix, include_track=False, include_seg=False):
     and only run if not already found
     """
     def _as_file(func):
-        needed_args = ["base_fname"]
+        needed_args = ["base_fname", "results_dir"]
         if include_track:
             needed_args.append("tracking_params")
         if include_seg:
@@ -125,12 +125,14 @@ def as_file(suffix, include_track=False, include_seg=False):
         @functools.wraps(func)
         @has_args(func, needed_args)
         def wrapper_as_file(*args, **kwargs):
-            og_arg_count, base_fname, tracking_params, segmentation_params =\
+            og_arg_count, base_fname, results_dir, \
+                tracking_params, segmentation_params =\
                 extract_added_args(
                     func,
-                    ["base_fname", "tracking_params", "segmentation_params"],
+                    ["base_fname", "results_dir",
+                     "tracking_params", "segmentation_params"],
                     args,
-                    includes=[True, include_track, include_seg])
+                    includes=[True, True, include_track, include_seg])
             this_file = get_fname(
                 base_fname, suffix,
                 tracking_params=tracking_params,
@@ -169,6 +171,10 @@ def as_file(suffix, include_track=False, include_seg=False):
                     meta["dependent"] = "trk"
                 else:
                     meta["dependent"] = "dwi"
+
+                # modify meta source to be relative
+                if "source" in meta:
+                    meta["source"] = op.relpath(meta["source"], results_dir)
 
                 meta_fname = get_fname(
                     base_fname, f"{drop_extension(suffix)}.json",

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -331,7 +331,9 @@ def tract_profiles(bundles,
 
     profile_dframe = pd.DataFrame(profile_dict)
     meta = dict(source=bundles,
-                parameters=get_default_args(afq_profile))
+                parameters=get_default_args(afq_profile),
+                scalars=list(scalar_dict.keys()),
+                bundles=list(seg_sft.bundle_names))
 
     return profile_dframe, meta
 

--- a/AFQ/tasks/tractography.py
+++ b/AFQ/tasks/tractography.py
@@ -299,10 +299,16 @@ def get_tractography_plan(kwargs):
         kwargs["tracking_params"]["seed_mask"] = ScalarImage(
             kwargs["best_scalar"])
         kwargs["tracking_params"]["seed_threshold"] = 0.2
+        logger.info((
+            "No seed mask given, using FA (or first scalar if none are FA)"
+            "thresholded to 0.2"))
     if kwargs["tracking_params"]["stop_mask"] is None:
         kwargs["tracking_params"]["stop_mask"] = ScalarImage(
             kwargs["best_scalar"])
         kwargs["tracking_params"]["stop_threshold"] = 0.2
+        logger.info((
+            "No stop mask given, using FA (or first scalar if none are FA)"
+            "thresholded to 0.2"))
 
     stop_mask = kwargs["tracking_params"]['stop_mask']
     seed_mask = kwargs["tracking_params"]['seed_mask']


### PR DESCRIPTION
Closes #1098 
Also adds some small changes:
 - make it more clear that you don't need to set the bids info when using participant afq
 - adds more info in profiles sidecar
 - makes co-located messages goto info, not warning, as they occur by default
 - add info on seed/stop mask