### PR TITLE
Make altair required

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     Pillow
     matplotlib
     numpy==1.23.5
+    altair
 
 zip_safe = False
 include_package_data = True
@@ -90,7 +91,6 @@ plot =
     pingouin>=0.3
     seaborn>=0.11.0
     ipython>=7.13.0,<=7.20.0
-    altair
 trx =
     trx-python
 


### PR DESCRIPTION
It's a lightweight library and currently it is used in the examples. So, currently, a user could install pyAFQ but get an error from trying to run an example from not having altair. currently, they would have to do pip install pyAFQ[plot]