### PR TITLE
[FIX] Remove unused parameter, filter_by_endpoints

### DIFF
--- a/AFQ/recognition/tests/test_recognition.py
+++ b/AFQ/recognition/tests/test_recognition.py
@@ -191,8 +191,7 @@ def test_exclusion_ROI():
         nib.load(hardi_fdata),
         mapping,
         slf_bundle,
-        reg_template,
-        filter_by_endpoints=False)
+        reg_template)
      
     npt.assert_equal(len(fiber_groups["Left Superior Longitudinal"]), 2)
 
@@ -204,8 +203,7 @@ def test_exclusion_ROI():
         nib.load(hardi_fdata),
         mapping,
         slf_bundle,
-        reg_template,
-        filter_by_endpoints=False)
+        reg_template)
 
     npt.assert_equal(len(fiber_groups["Left Superior Longitudinal"]), 1)
 

--- a/AFQ/tasks/viz.py
+++ b/AFQ/tasks/viz.py
@@ -236,33 +236,32 @@ def viz_indivBundle(base_fname,
                 "No streamlines found to visualize for "
                 + bundle_name)
 
-        if segmentation_params["filter_by_endpoints"]:
-            warped_rois = []
-            for reg_type in ['start', 'end']:
-                if reg_type in bundle_dict[
-                        roi_bname]:
-                    pp = bundle_dict[roi_bname][reg_type]
-                    pp = resample(
-                        pp.get_fdata(),
-                        reg_template,
-                        pp.affine,
-                        reg_template.affine).get_fdata()
+        warped_rois = []
+        for reg_type in ['start', 'end']:
+            if reg_type in bundle_dict[
+                    roi_bname]:
+                pp = bundle_dict[roi_bname][reg_type]
+                pp = resample(
+                    pp.get_fdata(),
+                    reg_template,
+                    pp.affine,
+                    reg_template.affine).get_fdata()
 
-                    atlas_roi = np.zeros(pp.shape)
-                    atlas_roi[np.where(pp > 0)] = 1
-                    warped_roi = auv.transform_inverse_roi(
-                        atlas_roi,
-                        mapping,
-                        bundle_name=roi_bname)
-                    warped_rois.append(warped_roi)
-            for i, roi in enumerate(warped_rois):
-                figure = viz_backend.visualize_roi(
-                    roi,
-                    name=f"{roi_bname} endpoint ROI {i}",
-                    flip_axes=flip_axes,
-                    inline=False,
-                    interact=False,
-                    figure=figure)
+                atlas_roi = np.zeros(pp.shape)
+                atlas_roi[np.where(pp > 0)] = 1
+                warped_roi = auv.transform_inverse_roi(
+                    atlas_roi,
+                    mapping,
+                    bundle_name=roi_bname)
+                warped_rois.append(warped_roi)
+        for i, roi in enumerate(warped_rois):
+            figure = viz_backend.visualize_roi(
+                roi,
+                name=f"{roi_bname} endpoint ROI {i}",
+                flip_axes=flip_axes,
+                inline=False,
+                interact=False,
+                figure=figure)
 
         for roi_fname in mapping_imap["rois"][roi_bname]:
             figure = viz_backend.visualize_roi(

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -539,7 +539,6 @@ def test_AFQ_slr():
             'full_segmented_cleaned_tractography.trk'),
         segmentation_params={
             "dist_to_waypoint": 10,
-            "filter_by_endpoints": False,
             "parallel_segmentation": {"engine": "serial"}},
         bundle_info=bd,
         mapping_definition=SlrMap(slr_kwargs={
@@ -811,8 +810,7 @@ def test_AFQ_data_waypoint():
                            n_seeds=200,
                            random_seeds=True,
                            rng_seed=42)
-    segmentation_params = dict(filter_by_endpoints=False,
-                               return_idx=True)
+    segmentation_params = dict(return_idx=True)
 
     afq_folder = op.join(bids_path, "derivatives/afq/sub-01/ses-01")
     os.makedirs(afq_folder, exist_ok=True)

--- a/docs/source/reference/kwargs.rst
+++ b/docs/source/reference/kwargs.rst
@@ -65,9 +65,32 @@ csd_tau: float, optional.
 	by default)
 	(see [1]_). Default: 0.1
 
+csd_fa_thr: float, optional.
+	The threshold on the FA used to calculate the single shell auto
+	response. Can be useful to reduce for baby subjects. Default: 0.7
+
 gq_sampling_length: float
 	Diffusion sampling length.
 	Default: 1.2
+
+rumba_wm_response: 1D or 2D ndarray or AxSymShResponse.
+	Able to take response[0] from auto_response_ssst.
+	default: array([0.0017, 0.0002, 0.0002])
+
+rumba_gm_response: float, optional
+	Mean diffusivity for GM compartment.
+	If None, then grey matter volume fraction is not computed.
+	Default: 0.8e-3
+
+rumba_csf_response: float, optional
+	Mean diffusivity for CSF compartment.
+	If None, then CSF volume fraction is not computed.
+	Default: 3.0e-3
+
+rumba_n_iter: int, optional
+	Number of iterations for fODF estimation.
+	Must be a positive int.
+	Default: 600
 
 opdt_sh_order: int
 	Spherical harmonics order for OPDT model. Must be even.
@@ -177,17 +200,11 @@ tracking_params: dict, optional
 	this dict may be ``AFQ.definitions.image.ImageFile`` instances.
 	If ``tracker`` is set to "pft" then ``stop_mask`` should be
 	an instance of ``AFQ.definitions.image.PFTImage``.
-	num_chunks can be specified to cause tracking to be done in
-	parallel using ray. If set to True it will use the number of
-	cores available on the machine - 1.
 
 import_tract: dict or str or None, optional
 	BIDS filters for inputing a user made tractography file,
 	or a path to the tractography file. If None, DIPY is used
-	to generate the tractography. Note that if you are importing 
-	tractography, you do not need to specify tracking_params as pyAFQ
-	will just load the provided tractogram rather than perform
-	tractography again.
+	to generate the tractography.
 	Default: None
 
 tractography_ngpus: int, optional

--- a/docs/source/reference/methods.rst
+++ b/docs/source/reference/methods.rst
@@ -59,6 +59,22 @@ dki_params:
     full path to a nifti file containing parameters for the DKI fit
 
 
+msdki_tf:
+    Mean Signal DKI DiffusionKurtosisFit object
+
+
+msdki_params:
+    full path to a nifti file containing parameters for the Mean Signal DKI fit
+
+
+msdki_msd:
+    full path to a nifti file containing the MSDKI mean signal diffusivity
+
+
+msdki_msk:
+    full path to a nifti file containing the MSDKI mean signal kurtosis
+
+
 csd_params:
     full path to a nifti file containing parameters for the CSD fit
 
@@ -89,6 +105,30 @@ gq_pmap:
 
 gq_ai:
     full path to a nifti file containing the anisotropic index from GQ
+
+
+rumba_model:
+    fit for RUMBA-SD model as documented on dipy reconstruction options
+
+
+rumba_params:
+    Takes the fitted RUMBA-SD model as input and returns the spherical harmonics coefficients (SHM).
+
+
+rumba_fit:
+    RUMBA FIT
+
+
+rumba_f_csf:
+    full path to a nifti file containing the CSF volume fraction for each voxel.
+
+
+rumba_f_gm:
+    full path to a nifti file containing the GM volume fraction for each voxel.
+
+
+rumba_f_wm:
+    full path to a nifti file containing the white matter volume fraction for each voxel.
 
 
 opdt_params:

--- a/examples/howto_examples/baby_afq.py
+++ b/examples/howto_examples/baby_afq.py
@@ -89,8 +89,6 @@ with zipfile.ZipFile(baby_zip, 'r') as zip_ref:
 # 4. In this case, tractography has already been run using
 #    `MRTRIX <https://www.mrtrix.org/>`, and is accessed using the
 #    `import_tract` key-word argument.
-# 5. We set `filter_by_endpoints = False` in the `segmentation_params` because
-#    endpoint ROIs are not defined from newborn bundles.
 
 myafq = GroupAFQ(
     bids_path=op.join(op.expanduser('~'),
@@ -102,8 +100,6 @@ myafq = GroupAFQ(
     bundle_info=abd.baby_bd(),
     import_tract={
         "suffix": "tractography", "scope": "mrtrix"},
-    segmentation_params={
-        "filter_by_endpoints": False},
 )
 
 ##########################################################################
@@ -135,7 +131,7 @@ viz = myafq.export("all_bundles_figure")
 # profiles in a plot on the left side of the page.
 #
 # If the baby bundles appear dark in the html visualization due to low FA values, you
-# can reduce the upper limit of the range in the `sbv_lims_bundles` option when 
+# can reduce the upper limit of the range in the `sbv_lims_bundles` option when
 # building your GroupAFQ object (e.g. `GroupAFQ(..., sbv_lims_bundles=[0, 0.5])`).
 
 


### PR DESCRIPTION
I broke this parameter over a year ago it looks like. I would like to remove it though, instead of fixing it, because it's redundant. If you don't want endpoints, don't put them in your bundledict!