### PR TITLE
[FIX] Update fetch.py with pediatric ARC ROI mapping

### DIFF
--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -368,10 +368,10 @@ def read_pediatric_templates(as_img=True, resample_to=False):
     # For the arcuate (AF/ARC), reuse the SLF ROIs
     pediatric_templates['ARC_roi1_L'] = pediatric_templates['SLF_roi1_L']
     pediatric_templates['ARC_roi1_R'] = pediatric_templates['SLF_roi1_R']
-    pediatric_templates['ARC_roi2_L'] = pediatric_templates['SLFt_roi2_L']
-    pediatric_templates['ARC_roi2_R'] = pediatric_templates['SLFt_roi2_R']
-    pediatric_templates['ARC_roi3_L'] = pediatric_templates['SLFt_roi3_L']
-    pediatric_templates['ARC_roi3_R'] = pediatric_templates['SLFt_roi3_R']
+    pediatric_templates['ARC_roi2_L'] = pediatric_templates['SLFt_roi3_L']
+    pediatric_templates['ARC_roi2_R'] = pediatric_templates['SLFt_roi3_R']
+    pediatric_templates['ARC_roi3_L'] = pediatric_templates['SLFt_roi2_L']
+    pediatric_templates['ARC_roi3_R'] = pediatric_templates['SLFt_roi2_R']
 
     # For the middle longitudinal fasciculus (MdLF) reuse ILF ROI
     pediatric_templates['MdLF_roi2_L'] = pediatric_templates['ILF_roi2_L']


### PR DESCRIPTION
Current mapping is:
ARC include0 = SLF include0
ARC include1 = SLF exclude0
ARC include2 = SLF include1

This results in premature clipping of the ARC as ARC include2 is between ARC include0 and ARC include1.

Swapping the mapping ensures that ARC is clipped correctly by redefining the ROIs mapped from the SLF.

Before
![image](https://github.com/yeatmanlab/pyAFQ/assets/137316255/8016ff1a-5c36-4f4e-a8f3-20da43cb5541)

After
![image](https://github.com/yeatmanlab/pyAFQ/assets/137316255/137c8a7b-b453-4896-8708-01f70cd43668)