### PR TITLE
[FIX] Fix bug in filtering by bval, where b0 calculation used mismatched dwi and gtab

### DIFF
--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -94,15 +94,13 @@ def get_data_gtab(dwi_data_file, bval_file, bvec_file, min_bval=None,
 
 @pimms.calc("b0")
 @as_file('_desc-b0_dwi.nii.gz')
-def b0(dwi_data_file, gtab):
+def b0(dwi, gtab):
     """
     full path to a nifti file containing the mean b0
     """
-    data = nib.load(dwi_data_file)
-    mean_b0 = np.mean(data.get_fdata()[..., gtab.b0s_mask], -1)
-    mean_b0_img = nib.Nifti1Image(mean_b0, data.affine)
-    meta = dict(b0_threshold=gtab.b0_threshold,
-                source=dwi_data_file)
+    mean_b0 = np.mean(dwi.get_fdata()[..., gtab.b0s_mask], -1)
+    mean_b0_img = nib.Nifti1Image(mean_b0, dwi.affine)
+    meta = dict(b0_threshold=gtab.b0_threshold)
     return mean_b0_img, meta
 
 

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -604,6 +604,15 @@ def test_AFQ_pydra():
     pga.export("dti_fa")
 
 
+def test_AFQ_filterb():
+    _, bids_path, _ = get_temp_hardi()
+    myafq = GroupAFQ(
+        bids_path=bids_path,
+        preproc_pipeline='vistasoft',
+        max_bval=1000)
+    myafq.export("b0")
+
+
 @pytest.mark.nightly_pft
 def test_AFQ_pft():
     """


### PR DESCRIPTION
Fixes the bug found in #1156 . Without the changes, the new test will throw the error:
```
IndexError: boolean index did not match indexed array along dimension 3; dimension is 160 but corresponding boolean dimension is 10
```